### PR TITLE
avoid leaking kernel address information to userspace by using

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -49,3 +49,6 @@ dev.cdrom.autoclose = 0
 # enable hard- and symlink protection (bnc#821585)
 fs.protected_hardlinks = 1
 fs.protected_symlinks = 1
+
+# restrict printed kernel ptrs (bnc#833774)
+kernel.kptr_restrict = 1


### PR DESCRIPTION
set this option to avoid leaking kernel addresses to userland. (bnc#833774) 

kernel.kptr_restrict=1 sysctl
