### PR TITLE
Rename _ls alias to z_ls for zsh.

### DIFF
--- a/files/etc/profile.d/ls.bash
+++ b/files/etc/profile.d/ls.bash
@@ -53,7 +53,7 @@ case "$-" in
 	    alias ls=_ls
 	    ;;
 	zsh)
-	    _ls ()
+	    z_ls ()
 	    {
 		local IFS=' '
 		command \ls $=LS_OPTIONS ${1+"$@"}


### PR DESCRIPTION
Rename _ls alias to z_ls for zsh. In zsh strings that start with an underscore are reserved for completion. This fixes bnc#836067 

See also http://www.zsh.org/mla/users//2013/msg00419.html
