### PR TITLE
change mistakenly root:users group to root:root (bnc#843230)

### DIFF
--- a/aaa_base.post
+++ b/aaa_base.post
@@ -156,9 +156,12 @@ for i in /etc/shadow ; do
 done
 #
 # Change primary group of nobody to nobody
+# and change mistakenly root:users group to root:root (bnc#843230)
 #
 if [ -x /usr/sbin/usermod ]; then
   /usr/sbin/usermod -g nobody nobody 2> /dev/null ||:
+
+  /usr/sbin/usermod -g root root 2> /dev/null ||:
 fi
 
 #


### PR DESCRIPTION
The live media for some time created root with group users due to a mistake in the kiwi xml (bnc#843230)

aaa_base %post is probably the best place to fix this up correctly.
