### PR TITLE
Muffle libGL error message when run under ssh (bnc#890189)

### DIFF
--- a/files/etc/profile.d/csh.ssh
+++ b/files/etc/profile.d/csh.ssh
@@ -17,5 +17,5 @@ if ( ${?SSH_CONNECTION} ) then
 	endif
     end
     unset lc val
-    setenv LIBGL_ALWAYS_INDIRECT 1
+    setenv LIBGL_DEBUG quiet
 endif

--- a/files/etc/profile.d/sh.ssh
+++ b/files/etc/profile.d/sh.ssh
@@ -25,6 +25,6 @@ if test -n "$SSH_CONNECTION" ; then
 	SSH_SENDS_LOCALE=yes
 	export SSH_SENDS_LOCALE
     fi
-    LIBGL_ALWAYS_INDIRECT=1
-    export LIBGL_ALWAYS_INDIRECT
+    LIBGL_DEBUG=quiet
+    export LIBGL_DEBUG
 fi


### PR DESCRIPTION
This changes:
  commit 22ad1610e9a4e72367524dad85eff75873a57b21
  Author: Werner Fink werner@suse.de
  Date:   Mon Jul 21 14:04:26 2014 +0200

```
Avoid libGL error via ssh (bnc#869172)

Signed-off-by: Werner Fink <werner@suse.de>
```

The change just avoids the error message, it doesn't prevent
libGL from attempting direct rendering. This way we don't rule
out direct rendering under ssh entirely as there are scenarios
where it will be usable.

Signed-off-by: Egbert Eich eich@suse.de
