### PR TITLE
Remove references to suseconfig in profiles and mkinfodir

### DIFF
--- a/files/etc/profile.d/profile.csh
+++ b/files/etc/profile.d/profile.csh
@@ -4,7 +4,6 @@
 # Used configuration files:
 #
 #     /etc/sysconfig/windowmanager
-#     /etc/sysconfig/suseconfig
 #     /etc/sysconfig/mail
 #     /etc/sysconfig/proxy
 #     /etc/sysconfig/console
@@ -14,7 +13,6 @@
 set noglob
 set sysconf=""
 foreach sys (/etc/sysconfig/windowmanager	\
-	     /etc/sysconfig/suseconfig		\
 	     /etc/sysconfig/mail		\
 	     /etc/sysconfig/proxy		\
 	     /etc/sysconfig/console		\
@@ -30,21 +28,8 @@ foreach line ( "`/bin/grep -vh '^#' $sysconf`" )
     set arr=( $val )
     eval set val="${arr[2-]}"
     switch (${line:q})
-    case CWD_IN_ROOT_PATH=*:
-	if ( ${line:q} !~ *=*yes* ) continue
-	if ( "$path[*]" =~ *.* )    continue
-	if ( $uid <  100 ) set -l path=( $path . )
-	breaksw
-    case CWD_IN_USER_PATH=*:
-	if ( ${line:q} !~ *=*yes* ) continue
-	if ( "$path[*]" =~ *.* )    continue
-	if ( $uid >= 100 ) set -l path=( $path . )
-	breaksw
     case FROM_HEADER=*:
 	setenv FROM_HEADER "${val:q}"
-	breaksw
-    case SCANNER_TYPE=*:
-	setenv SCANNER_TYPE "${val:q}"
 	breaksw
     case PROXY_ENABLED=*:
 	set proxy_enabled="${val:q}"

--- a/files/etc/profile.d/profile.csh
+++ b/files/etc/profile.d/profile.csh
@@ -28,6 +28,16 @@ foreach line ( "`/bin/grep -vh '^#' $sysconf`" )
     set arr=( $val )
     eval set val="${arr[2-]}"
     switch (${line:q})
+    case CWD_IN_ROOT_PATH=*:
+	if ( ${line:q} !~ *=*yes* ) continue
+	if ( "$path[*]" =~ *.* ) continue
+	if ( $uid < 100 ) set -l path=( $path . )
+	breaksw
+    case CWD_IN_USER_PATH=*:
+	if ( ${line:q} !~ *=*yes* ) continue
+	if ( "$path[*]" =~ *.* ) continue
+	if ( $uid >= 100 ) set -l path=( $path . )
+	breaksw
     case FROM_HEADER=*:
 	setenv FROM_HEADER "${val:q}"
 	breaksw

--- a/files/etc/profile.d/profile.sh
+++ b/files/etc/profile.d/profile.sh
@@ -4,7 +4,6 @@
 # Used configuration files:
 #
 #     /etc/sysconfig/windowmanager
-#     /etc/sysconfig/suseconfig
 #     /etc/sysconfig/mail
 #     /etc/sysconfig/proxy
 #     /etc/sysconfig/console
@@ -12,7 +11,6 @@
 #
 
 for sys in /etc/sysconfig/windowmanager	\
-	   /etc/sysconfig/suseconfig	\
 	   /etc/sysconfig/mail		\
 	   /etc/sysconfig/proxy		\
 	   /etc/sysconfig/console	\
@@ -25,21 +23,9 @@ do
         esac
 	eval val=${line#*=}
 	case "$line" in
-	CWD_IN_ROOT_PATH=*)
-	    test "$val" = "yes" || continue
-	    test $UID -lt 100 && PATH=$PATH:.
-	    ;;
-	CWD_IN_USER_PATH=*)
-	    test "$val" = "yes" || continue
-	    test $UID -ge 100 && PATH=$PATH:.
-	    ;;
 	FROM_HEADER=*)
 	    FROM_HEADER="${val}"
 	    export FROM_HEADER
-	    ;;
-	SCANNER_TYPE=*)
-	    SCANNER_TYPE="${val}"
-	    export SCANNER_TYPE
 	    ;;
 	PROXY_ENABLED=*)
 	    PROXY_ENABLED="${val}"

--- a/files/etc/profile.d/profile.sh
+++ b/files/etc/profile.d/profile.sh
@@ -23,6 +23,14 @@ do
         esac
 	eval val=${line#*=}
 	case "$line" in
+	CWD_IN_ROOT_PATH=*)
+      test "$val" = "yes" || continue
+      test $UID -lt 100 && PATH=$PATH:.
+      ;;
+	CWD_IN_USER_PATH=*)
+      test "$val" = "yes" || continue
+      test $UID -ge 100 && PATH=$PATH:.
+      ;;
 	FROM_HEADER=*)
 	    FROM_HEADER="${val}"
 	    export FROM_HEADER

--- a/files/etc/profile.d/profile.sh
+++ b/files/etc/profile.d/profile.sh
@@ -24,13 +24,13 @@ do
 	eval val=${line#*=}
 	case "$line" in
 	CWD_IN_ROOT_PATH=*)
-      test "$val" = "yes" || continue
-      test $UID -lt 100 && PATH=$PATH:.
-      ;;
+	    test "$val" = "yes" || continue
+	    test $UID -lt 100 && PATH=$PATH:.
+	    ;;
 	CWD_IN_USER_PATH=*)
-      test "$val" = "yes" || continue
-      test $UID -ge 100 && PATH=$PATH:.
-      ;;
+	    test "$val" = "yes" || continue
+	    test $UID -ge 100 && PATH=$PATH:.
+	    ;;
 	FROM_HEADER=*)
 	    FROM_HEADER="${val}"
 	    export FROM_HEADER

--- a/files/usr/bin/mkinfodir
+++ b/files/usr/bin/mkinfodir
@@ -340,8 +340,7 @@ File: dir	Node: Top	This is the top of the INFO tree
     Typing "d" returns here,       typing "?" lists all INFO commands,
     typing "q" exits,     typing "h" gives a  primer for first-timers,
     pressing 2nd button on a highlighted word follows cross-reference.
-
- ---- AUTOCONFIGURED BY SuSEConfig: EDIT WITH CARE: ----
+ ---- EDIT WITH CARE: ----
  ---- Only descriptive text for otherwise empty topics will survive ----
 
 * Menu: The list of major topics begins on the next line.

--- a/files/usr/bin/mkinfodir
+++ b/files/usr/bin/mkinfodir
@@ -340,6 +340,7 @@ File: dir	Node: Top	This is the top of the INFO tree
     Typing "d" returns here,       typing "?" lists all INFO commands,
     typing "q" exits,     typing "h" gives a  primer for first-timers,
     pressing 2nd button on a highlighted word follows cross-reference.
+    
  ---- EDIT WITH CARE: ----
  ---- Only descriptive text for otherwise empty topics will survive ----
 


### PR DESCRIPTION
There are still references to suseconfig in the profiles (/etc/profiles.d/). Three variables seem to be obsolete: CWD_IN_ROOT_PATH, CWD_IN_USER_PATH and SCANNER_TYPE. They are not present in the configuration files read by the profiles, they were probably in suseconfig.

mkinfodir also mentions suseconfig.

Let's clean that.