### PR TITLE
Avoid sourcing /etc/bash_completion.d twice

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -275,9 +275,12 @@ case "$-" in
 	    elif test -s /etc/profile.d/complete.bash ; then
 		. /etc/profile.d/complete.bash
 	    fi
-	    for s in /etc/bash_completion.d/*.sh ; do
-		test -r $s && . $s
-	    done
+	    # Do not source twice if already handled by bash-completion
+	    if [[ $BASH_COMPLETION_COMPAT_DIR != /etc/bash_completion.d ]]; then
+		for s in /etc/bash_completion.d/*.sh ; do
+		    test -r $s && . $s
+		done
+	    fi
 	    if test -e $HOME/.bash_completion ; then
 		. $HOME/.bash_completion
 	    fi


### PR DESCRIPTION
If bash-completion is installed (default on openSUSE 13.2+) it
already handles this directory; it is also careful to skip some
files that are known to be broken (like acroread.sh).

Ref: http://bugzilla.suse.com/show_bug.cgi?id=907873

Signed-off-by: Andrei Borzenkov arvidjaar@gmail.com
