### PR TITLE
Change DEFAULT_WM to plasma5

### DIFF
--- a/files/var/adm/fillup-templates/sysconfig.windowmanager
+++ b/files/var/adm/fillup-templates/sysconfig.windowmanager
@@ -6,7 +6,7 @@
 #
 # Here you can set the default window manager (kde, fvwm, ...)
 # changes here require at least a re-login
-DEFAULT_WM="kde-plasma"
+DEFAULT_WM="plasma5"
 
 ## Type:	yesno
 ## Default:	yes


### PR DESCRIPTION
Will switching default KDE to Plasma 5 soon, and DEFAULT_WM need change to plasma5, which provided by plasma5-session.