### PR TITLE
Readd CWD_IN_{USER,ROOT}_PATH functionality

### DIFF
--- a/aaa_base.post
+++ b/aaa_base.post
@@ -62,7 +62,7 @@ if ! [ -d /etc/sysconfig ] ; then
 fi
 for i in language backup \
 	proxy windowmanager \
-	news ; do
+	news profile ; do
 %{fillup_only -n $i}
 done
 if [ -e /etc/sysconfig/sysctl ]; then

--- a/files/etc/profile.d/profile.csh
+++ b/files/etc/profile.d/profile.csh
@@ -9,6 +9,7 @@
 #     /etc/sysconfig/proxy
 #     /etc/sysconfig/console
 #     /etc/sysconfig/news
+#     /etc/sysconfig/profile
 #
 
 set noglob
@@ -18,7 +19,8 @@ foreach sys (/etc/sysconfig/windowmanager	\
 	     /etc/sysconfig/mail		\
 	     /etc/sysconfig/proxy		\
 	     /etc/sysconfig/console		\
-	     /etc/sysconfig/news)
+	     /etc/sysconfig/news                \
+             /etc/sysconfig/profile)
     if (! -s ${sys:q} ) continue
     set sysconf="${sysconf} ${sys}"
 end
@@ -33,12 +35,12 @@ foreach line ( "`/bin/grep -vh '^#' $sysconf`" )
     case CWD_IN_ROOT_PATH=*:
 	if ( ${line:q} !~ *=*yes* ) continue
 	if ( "$path[*]" =~ *.* )    continue
-	if ( $uid <  100 ) set -l path=( $path . )
+	if ( $uid ==  0 ) set -l path=( $path . )
 	breaksw
     case CWD_IN_USER_PATH=*:
 	if ( ${line:q} !~ *=*yes* ) continue
 	if ( "$path[*]" =~ *.* )    continue
-	if ( $uid >= 100 ) set -l path=( $path . )
+	if ( $uid >= 1000 ) set -l path=( $path . )
 	breaksw
     case FROM_HEADER=*:
 	setenv FROM_HEADER "${val:q}"

--- a/files/etc/profile.d/profile.sh
+++ b/files/etc/profile.d/profile.sh
@@ -9,6 +9,7 @@
 #     /etc/sysconfig/proxy
 #     /etc/sysconfig/console
 #     /etc/sysconfig/news
+#     /etc/sysconfig/profile
 #
 
 for sys in /etc/sysconfig/windowmanager	\
@@ -16,7 +17,8 @@ for sys in /etc/sysconfig/windowmanager	\
 	   /etc/sysconfig/mail		\
 	   /etc/sysconfig/proxy		\
 	   /etc/sysconfig/console	\
-	   /etc/sysconfig/news
+	   /etc/sysconfig/news          \
+           /etc/sysconfig/profile
 do
     test -s $sys || continue
     while read line ; do
@@ -27,11 +29,11 @@ do
 	case "$line" in
 	CWD_IN_ROOT_PATH=*)
 	    test "$val" = "yes" || continue
-	    test $UID -lt 100 && PATH=$PATH:.
+	    test $UID -eq 0 && PATH=$PATH:.
 	    ;;
 	CWD_IN_USER_PATH=*)
 	    test "$val" = "yes" || continue
-	    test $UID -ge 100 && PATH=$PATH:.
+	    test $UID -ge 1000 && PATH=$PATH:.
 	    ;;
 	FROM_HEADER=*)
 	    FROM_HEADER="${val}"

--- a/files/var/adm/fillup-templates/sysconfig.profile
+++ b/files/var/adm/fillup-templates/sysconfig.profile
@@ -1,0 +1,17 @@
+## Path:        Users/Profile
+## Description: Users profiles management
+## Type:        yesno
+## Default:     no
+#
+# This defines whether the current working directory should
+# be included in the "root" user's path.
+#
+CWD_IN_ROOT_PATH="no"
+
+## Type:        yesno
+## Default:     no
+#
+# This defines whether the current working directory should
+# be included in regular users' paths.
+#
+CWD_IN_USER_PATH="no"


### PR DESCRIPTION
- add a sysconfig file to configure these variables
- modify profile.csh and profile.sh (root id is 0, users ids are above 1000)

We have talked about this functionality in [pr#19](https://github.com/openSUSE/aaa_base/pull/19) (which is still pending by the way).
This feature has been (unintentionally?) lost with the drop of SuSEconfig.
Also YaST Security module used this feature in the past. I may readd it there too if they are interested.