### PR TITLE
Enable SysRq dump by default

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -40,8 +40,8 @@ fs.inotify.max_user_watches = 65536
 #        256 - allow nicing of all RT tasks
 #
 # For further information see /usr/src/linux/Documentation/sysrq.txt
-# default 176 = 128+32+16
-kernel.sysrq = 176
+# default 184 = 128+32+16+8
+kernel.sysrq = 184
 
 # Disable auto-closing of cd tray bnc#659153
 dev.cdrom.autoclose = 0


### PR DESCRIPTION
Commit 7c4b61320d0288ef20ef8f551100e5ea298fa79e adds one more step in configuring a system for kernel dumps. Admittedly, the "dump" action is destructive, but so is reboot/poweroff, which was already enabled.

Honestly, it's not clear to me what was the intention of limiting enabled sysrq actions, and why this subset should be default.