### PR TITLE
rename path() to susepath() to avoid using a general name.

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -66,7 +66,7 @@ fi
 #
 # Call common progams from /bin or /usr/bin only
 #
-path ()
+susepath ()
 {
     if test -x /usr/bin/$1 ; then
 	${1+"/usr/bin/$@"}
@@ -79,8 +79,8 @@ path ()
 #
 # ksh/ash sometimes do not know
 #
-test -z "$UID"  && readonly  UID=`path id -ur 2> /dev/null`
-test -z "$EUID" && readonly EUID=`path id -u  2> /dev/null`
+test -z "$UID"  && readonly  UID=`susepath id -ur 2> /dev/null`
+test -z "$EUID" && readonly EUID=`susepath id -u  2> /dev/null`
 
 test -s /etc/profile.d/ls.bash && . /etc/profile.d/ls.bash
 
@@ -88,8 +88,8 @@ test -s /etc/profile.d/ls.bash && . /etc/profile.d/ls.bash
 # Avoid trouble with Emacs shell mode
 #
 if test "$EMACS" = "t" ; then
-    path tset -I -Q
-    path stty cooked pass8 dec nl -echo
+    susepath tset -I -Q
+    susepath stty cooked pass8 dec nl -echo
 fi
 
 #
@@ -129,7 +129,7 @@ case "$-" in
 	#
 	# Set xterm prompt with short path (last 18 characters)
 	#
-	if path tput hs 2>/dev/null || path tput -T $TERM+sl hs 2>/dev/null ; then
+	if susepath tput hs 2>/dev/null || susepath tput -T $TERM+sl hs 2>/dev/null ; then
 	    #
 	    # Mirror prompt in terminal "status line", which for graphical
 	    # terminals usually is the window title. KDE konsole in
@@ -141,9 +141,9 @@ case "$-" in
 		_isl=$(echo -en '\e]1;')
 		_fsl=$(echo -en '\007')
 	    else
-		_tsl=$(path tput tsl 2>/dev/null || path tput -T $TERM+sl tsl 2>/dev/null)
+		_tsl=$(susepath tput tsl 2>/dev/null || susepath tput -T $TERM+sl tsl 2>/dev/null)
 		_isl=''
-		_fsl=$(path tput fsl 2>/dev/null || path tput -T $TERM+sl fsl 2>/dev/null)
+		_fsl=$(susepath tput fsl 2>/dev/null || susepath tput -T $TERM+sl fsl 2>/dev/null)
 	    fi
 	    _sc=$(tput sc 2>/dev/null)
 	    _rc=$(tput rc 2>/dev/null)
@@ -175,8 +175,8 @@ case "$-" in
 	# Other prompting for root
 	if test "$UID" -eq 0  ; then
 	    if test -n "$TERM" -a -t ; then
-	    	_bred="$(path tput bold 2> /dev/null; path tput setaf 1 2> /dev/null)"
-	    	_sgr0="$(path tput sgr0 2> /dev/null)"
+		_bred="$(susepath tput bold 2> /dev/null; susepath tput setaf 1 2> /dev/null)"
+		_sgr0="$(susepath tput sgr0 2> /dev/null)"
 	    fi
 	    # Colored root prompt (see bugzilla #144620)
 	    if test -n "$_bred" -a -n "$_sgr0" ; then

--- a/files/etc/csh.login
+++ b/files/etc/csh.login
@@ -11,7 +11,7 @@ set noglob
 #   
 # Call common progams from /bin or /usr/bin only
 #   
-alias path 'if ( -x /bin/\!^ ) /bin/\!*; if ( -x /usr/bin/\!^ ) /usr/bin/\!*'
+alias susepath 'if ( -x /bin/\!^ ) /bin/\!*; if ( -x /usr/bin/\!^ ) /usr/bin/\!*'
 if ( -x /bin/id ) then
     set id=/bin/id
 else if ( -x /usr/bin/id ) then
@@ -27,14 +27,14 @@ if ( -o /dev/$tty && -c /dev/$tty && ${?prompt} ) then
     if ( "$TERM" == "unknown" ) setenv TERM linux
     if ( "$TERM" == "ibm327x" ) setenv TERM dumb
     if ( ! ${?SSH_TTY} && "$TERM" != "dumb" ) then
-	path stty sane cr0 pass8 dec
-	path tset -I -Q
+	susepath stty sane cr0 pass8 dec
+	susepath tset -I -Q
     endif
     # on iSeries virtual console, detect screen size and terminal
     if ( -d /proc/iSeries && ( $tty == "tty1" || "$tty" == "console")) then
 	setenv LINES   24
 	setenv COLUMNS 80
-	eval `path initviocons -q -e -c`
+	eval `susepath initviocons -q -e -c`
     endif
     settc km yes
 endif

--- a/files/etc/profile
+++ b/files/etc/profile
@@ -63,7 +63,7 @@ fi
 #
 # Call common progams from /bin or /usr/bin only
 #
-path ()
+susepath ()
 {
     command -p ${1+"$@"}
 }
@@ -71,7 +71,7 @@ path ()
 #
 # Initialize terminal
 #
-tty=`path tty 2> /dev/null`
+tty=`susepath tty 2> /dev/null`
 test $? -ne 0 && tty=""
 if test -O "$tty" -a -n "$PS1"; then
     test -z "${TERM}"		&& { TERM=linux; export TERM; }
@@ -79,15 +79,15 @@ if test -O "$tty" -a -n "$PS1"; then
     test "${TERM}" = "ibm327x"	&& { TERM=dumb;  export TERM; }
     # Do not change settings on local line if connected to remote
     if test -z "$SSH_TTY" -a "${TERM}" != "dumb" ; then
-	path stty sane cr0 pass8 dec
-	path tset -I -Q
+	susepath stty sane cr0 pass8 dec
+	susepath tset -I -Q
     fi
     # on iSeries virtual console, detect screen size and terminal
     if test -d /proc/iSeries -a \( "$tty" = "/dev/tty1" -o "$tty" = "/dev/console" \) ; then
         LINES=24
 	COLUMNS=80
 	export LINES COLUMNS TERM
-	eval `path initviocons -q -e`
+	eval `susepath initviocons -q -e`
     fi
 fi
 unset TERMCAP
@@ -118,9 +118,9 @@ fi
 #
 # ksh/ash sometimes do not know
 #
-test -z "$UID"  && readonly  UID=`path id -ur 2> /dev/null`
-test -z "$EUID" && readonly EUID=`path id -u  2> /dev/null`
-test -z "$USER" && USER=`path id -un 2> /dev/null`
+test -z "$UID"  && readonly  UID=`susepath id -ur 2> /dev/null`
+test -z "$EUID" && readonly EUID=`susepath id -u  2> /dev/null`
+test -z "$USER" && USER=`susepath id -un 2> /dev/null`
 test -z "$MAIL" && MAIL=/var/spool/mail/$USER
 if test -x /bin/uname ; then
     test -z "$HOST" && HOST=`/bin/uname -n`


### PR DESCRIPTION
i have a tool program called path. opensuse by default defines a bash function in bashrc called path by default which overrides any other program named path. rename to namespace suse as susepath in order to avoid using a general name for a suse only bash function.