### PR TITLE
Add a number of audio/video formats to be colorized

### DIFF
--- a/files/etc/DIR_COLORS
+++ b/files/etc/DIR_COLORS
@@ -106,32 +106,44 @@ EXEC 00;32
 # image formats
 .avi  01;35
 .bmp  01;35
+.dl   01;35
 .fli  01;35
 .gif  01;35
+.gl   01;35
 .jpg  01;35
 .jpeg 01;35
+.mkv  01;35
 .mng  01;35
 .mov  01;35
+.mp4  01;35
 .mpg  01;35
 .pcx  01;35
 .pbm  01;35
 .pgm  01;35
 .png  01;35
 .ppm  01;35
+.svg  01;35
 .tga  01;35
 .tif  01;35
-.xbm  01;35
-.xpm  01;35
-.dl   01;35
-.gl   01;35
+.webm 01;35
+.webp 01;35
 .wmv  01;35
+.xbm  01;35
+.xcf  01;35
+.xpm  01;35
 
 # sound formats
 .aiff 00;32
+.ape  00;32
 .au   00;32
+.flac 00;32
+.m4a  00;32
 .mid  00;32
 .mp3  00;32
+.mpc  00;32
 .ogg  00;32
 .voc  00;32
 .wav  00;32
+.wma  00;32
+.wv   00;32
 


### PR DESCRIPTION
Added mkv, mp4, svg, webm, webp, xcf as colorized image/video formats
and ape, flac, m4a, mpc, wma, wv as colorized audio formats.
The lists are alphabetically ordered, so I also moved .dl, .gl and .wmv
to their correct positions.