### PR TITLE
Revert "Avoid NAT on Bridges. Bridges are L2 devices, really."

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -54,7 +54,3 @@ fs.protected_symlinks = 1
 
 # restrict printed kernel ptrs (bnc#833774)
 kernel.kptr_restrict = 1
-
-# Disable NAT'ing on Linuxbridges (bnc#845496)
-net.bridge.bridge-nf-call-ip6tables = 0
-net.bridge.bridge-nf-call-iptables = 0


### PR DESCRIPTION
This reverts commit 45d178b48197f2b1ecfbff35ee776df5068a6bbf.

Disabling netfilter on bridges by default is a deviation from upstream
which was originally meant only for cloud products. It was propagated
into Factory without consulting networking developers and without any
reasoning, except the "bridges are L2 devices, really" in subject which
is not really true (e.g. our default virtualization host setup assigns
IP addresses to a bridge).

Moreover, the sysctl only exists when bridge module is loaded so that
setting it in sysctl files is unreliable and causes inconsistencies
(bsc#1003886).