### PR TITLE
tumbleweed-update script

### DIFF
--- a/files/usr/bin/tumbleweed-update
+++ b/files/usr/bin/tumbleweed-update
@@ -1,0 +1,3 @@
+#!/usr/bin/sh
+
+zypper dist-upgrade --no-allow-vendor-change --no-recommends $@


### PR DESCRIPTION
After some discussion ([r/openSUSE](https://www.reddit.com/r/openSUSE/comments/62ecku/the_proper_way_to_update_tumbleweed/), [lwn.net](https://lwn.net/Articles/717489/)) that it is not easy for newcomers to correctly update Tumbleweed, I came up with the idea to have an `tumbleweed-update` script which just calls zypper with some arguments. There is an open bug [#1031756](https://bugzilla.opensuse.org/show_bug.cgi?id=1031756) about the suggested change.

If this PR is accepted it should maybe be added to ´aaa_base-extras` only for Tumbleweed. I hope this is the right place to submit the script.