### PR TITLE
Use 'default' as standard window manager

### DIFF
--- a/files/var/adm/fillup-templates/sysconfig.windowmanager
+++ b/files/var/adm/fillup-templates/sysconfig.windowmanager
@@ -1,12 +1,13 @@
 ## Path:	Desktop/Window manager
 ## Description:	
 ## Type:	string(gnome,kde-plasma,kde,plasma5,lxde,xfce,twm,icewm,enlightenment)
-## Default:	kde-plasma
+## Default:	default
 ## Config:      profiles,kde,susewm
 #
 # Here you can set the default window manager (kde, fvwm, ...)
 # changes here require at least a re-login
-DEFAULT_WM="kde-plasma"
+# 'default' is a session handled by update-alternatives, use "yast2 alternatives" to update
+DEFAULT_WM="default"
 
 ## Type:	yesno
 ## Default:	yes


### PR DESCRIPTION
'default' is managed using update-alternatives and allows for priorization
of WM's upon installation. Especially paired with the new, role-based
desktop selection this is nescessary, as YaST no longer has a way to properly
decide what WM to set as default (only GNOME and KDE still have this capability)

Anybody installing the system using 'custom roles' and adding Desktop Environments
was ending up with a system that would not have working autologin just after the
installation.

http://bugzilla.opensuse.org/show_bug.cgi?id=1030873