### PR TITLE
Deprecate DEFAULT_WM in sysconfig.windowmanager

### DIFF
--- a/files/var/adm/fillup-templates/sysconfig.windowmanager
+++ b/files/var/adm/fillup-templates/sysconfig.windowmanager
@@ -1,12 +1,16 @@
 ## Path:	Desktop/Window manager
 ## Description:	
-## Type:	string(gnome,kde-plasma,kde,plasma5,lxde,xfce,twm,icewm,enlightenment)
-## Default:	kde-plasma
+## Type:	string(default,gnome,plasma5,lxde,xfce,twm,icewm,enlightenment)
+## Default:	default
 ## Config:      profiles,kde,susewm
 #
 # Here you can set the default window manager (kde, fvwm, ...)
-# changes here require at least a re-login
-DEFAULT_WM="kde-plasma"
+# changes here require at least a re-login.
+#
+# This value is deprecated and not read by most display managers.
+# Use 'update-alternatives --config default-xsession.desktop' for configuration instead.
+
+DEFAULT_WM="default"
 
 ## Type:	yesno
 ## Default:	yes


### PR DESCRIPTION
- Mark it as deprecated and mention the replacement
- Make default.desktop the default, so that xdm and friends respect default-xsession.desktop
- Remove mentions of "kde" and "kde-plasma", they do not exist anymore.

Needed to allow change in yast2-installation (currently blocking factory staging :E)