### PR TITLE
Fix double sourcing of /etc/bash_completion.d

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -291,7 +291,7 @@ case "$-" in
 		. /etc/profile.d/complete.bash
 	    fi
 	    # Do not source twice if already handled by bash-completion
-	    if [[ $BASH_COMPLETION_COMPAT_DIR != /etc/bash_completion.d ]]; then
+	    if [[ -n $BASH_COMPLETION_COMPAT_DIR && $BASH_COMPLETION_COMPAT_DIR != /etc/bash_completion.d ]]; then
 		for s in /etc/bash_completion.d/*.sh ; do
 		    test -r $s && . $s
 		done


### PR DESCRIPTION
Bash-completion no longer defines BASH_COMPLETION_COMPAT_DIR as of
version 2.6. See https://github.com/scop/bash-completion/commit/c41a76237bc9dcbfa326eeddd026b66d7646d91d 

If something else defines BASH_COMPLETION_COMPAT_DIR,
bash-completion will respect it, so we should too, but if
BASH_COMPLETION_COMPAT_DIR is undefined, bash-completion will default to
and source /etc/bash_completion.d. To avoid sourcing /etc/bash_completion.d twice, test if BASH_COMPLETION_COMPAT_DIR has been set.