### PR TITLE
profile: set umask in WSL

### DIFF
--- a/files/etc/profile.d/wsl.sh
+++ b/files/etc/profile.d/wsl.sh
@@ -1,0 +1,6 @@
+# WSL does not utilitze this pam functionality currently.
+if test `umask` = 0000; then
+    UMASK_LOGIN_DEFS=`sed -ne 's/^UMASK[[:space:]]*//p' /etc/login.defs`
+    test "$UMASK_LOGIN_DEFS" && umask "$UMASK_LOGIN_DEFS"
+    unset UMASK_LOGIN_DEFS
+fi


### PR DESCRIPTION
When running on a Windows Subsystems for Linux, umask is not set
through pam_umask.  Therefore we set it here again in that case if
not set previously.