### PR TITLE
Add support for /usr/bin/fish

### DIFF
--- a/files/etc/shells
+++ b/files/etc/shells
@@ -21,3 +21,4 @@
 /usr/bin/bash
 /usr/bin/tcsh
 /usr/bin/zsh
+/usr/bin/fish


### PR DESCRIPTION
I stopped being able to login last week because /usr/bin/fish was no longer in the list of shells.