### PR TITLE
Add option --version to /usr/sbin/service

### DIFF
--- a/files/usr/sbin/service
+++ b/files/usr/sbin/service
@@ -3,6 +3,8 @@
 # /sbin/service		Handle boot and runlevel services
 #
 
+VERSION="18.02.16"
+
 sd_booted()
 {
     test -d /sys/fs/cgroup/systemd/
@@ -152,6 +154,12 @@ usage ()
     exit 1
 }
 
+version ()
+{
+    echo "${0##*/} ver. ${VERSION}"
+    exit 0
+}
+
 help ()
 {
     echo "Usage: ${0##*/} [<options> | <service> [<args>]]"
@@ -184,6 +192,7 @@ while test $# -gt 0; do
     case "$opt" in
     status-all|s)   status_all=1 ;;
     full-restart) full_restart=1 ;;
+    version)		    version ;;
     h*)			    help ;;
     *)			   usage ;;
     esac


### PR DESCRIPTION
On current SuSE Linux releases like SLES or OpenSuSE the [Solr installer stops with the error message "Script requires the 'service' command"](https://issues.apache.org/jira/browse/SOLR-11853).

This happens because before installation the installer checks if the used command "service" exists by its option "service --version".

The command line option "--version" doesn't exist for "service" on current SuSE Linux stable releases.

Since the command "service" is there i added the needed option "--version".