### PR TITLE
Fix string test to arithmetic test in /etc/profile.d/wsl.sh for 000, 00, and 0 umask

### DIFF
--- a/files/etc/profile.d/wsl.sh
+++ b/files/etc/profile.d/wsl.sh
@@ -7,7 +7,7 @@ if test -n "$IS_WSL" ; then
     if test -n "$ORIG_PATH" ; then
 	PATH=$ORIG_PATH:$PATH
     fi
-    if test $(umask) = 0000; then
+    if test $(umask) -eq 0; then
 	UMASK_LOGIN_DEFS=$(sed -ne 's/^UMASK[[:space:]]*//p' /etc/login.defs)
 	test "$UMASK_LOGIN_DEFS" && umask "$UMASK_LOGIN_DEFS"
 	unset UMASK_LOGIN_DEFS


### PR DESCRIPTION
= test operator compares literal string "0000" whereas -eq compares integer value which works with shells that truncate the umask.
zsh sets to 000 in WSL and 000 is not = 0000 but it does -eq 0

This is the least invasive change I could think of that solves the issue. It will match 0, 00, 000, and 0000. Most shells set 4 digit umask, so the current 0000 works, except csh which has it's own file, but maybe other shell do this too like fish, yash, posh, or mksh.

Also, the wsl.csh should probably also be changed to use (`umask` <= 0) or equivalent, but csh seems to strip all leading zeros anyways so is not needed.