### PR TITLE
Clean up the no_proxy value: not all clients ignore spaces (bsc#1089796)

### DIFF
--- a/files/usr/share/fillup-templates/sysconfig.proxy
+++ b/files/usr/share/fillup-templates/sysconfig.proxy
@@ -57,6 +57,6 @@ SOCKS5_SERVER=""
 ## Type:	string(localhost)
 ## Default:	localhost
 #
-# Example: NO_PROXY="www.me.de, .do.main, localhost"
+# Example: NO_PROXY="www.me.de,.do.main,localhost"
 #
-NO_PROXY="localhost, 127.0.0.1"
+NO_PROXY="localhost,127.0.0.1"


### PR DESCRIPTION
[bsc#1089796](https://bugzilla.suse.com/show_bug.cgi?id=1089796)