### PR TITLE
bash.bashrc: Change =~ test to *globs*. Fixes mkshrc.

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -137,7 +137,7 @@ case "$-" in
 	    # addition needs to have "%w" in the "tabs" setting, ymmv for
 	    # other console emulators.
 	    #
-	    if [[ $TERM =~ xterm* ]] ; then
+	    if [[ $TERM = *xterm* ]] ; then
 		_tsl=$(echo -en '\e]2;')
 		_isl=$(echo -en '\e]1;')
 		_fsl=$(echo -en '\007')


### PR DESCRIPTION
mksh shares bash.bashrc which has syntax error in `[[ $TERM =~ xterm* ]]` on Leap15 and TW.
```        mksh: /etc/mkshrc[140]: syntax error: unexpected operator/operand '=~'        ```

If this test is trying to match xterm* but NOT match anything with a prefix before xterm (such as `screen.xterm-256color`), then it should have been `[[ $TERM = xterm* ]]` but with Leap15, TW, and current git code the `[[ $TERM =~ xterm* ]]` will match anything with "xterm" in its name.

If we ARE trying to match anything with "xterm" in its name then it should be `[[ $TERM = *xterm* ]]` which has same result as the current code without breaking some shells.

As far as I can tell, this syntax is supported by all shells that read this file, although maybe some have different glob pattern matching behavior? Bash, (ba)sh, Dash, ksh93, mksh, and lksh seemed to return the same behavior.

``` diff

@@ -137,7 +137,7 @@ case "$-" in
 	    # addition needs to have "%w" in the "tabs" setting, ymmv for
 	    # other console emulators.
 	    #
-	    if [[ $TERM =~ xterm* ]] ; then
+	    if [[ $TERM = *xterm* ]] ; then
 		_tsl=$(echo -en '\e]2;')
 		_isl=$(echo -en '\e]1;')
 		_fsl=$(echo -en '\007')

```