### PR TITLE
Sync x-genesis-rom extensions with freedesktop DB

### DIFF
--- a/files/etc/mime.types
+++ b/files/etc/mime.types
@@ -1125,7 +1125,7 @@ application/x-gameboy-rom                        gb
 application/x-gca-compressed                     gca
 application/x-gdbm                               
 application/x-gdesklets-display                  display
-application/x-genesis-rom                        gen md
+application/x-genesis-rom                        gen smd
 application/x-gettext-translation                gmo
 application/x-glabels                            glabels
 application/x-glade                              glade


### PR DESCRIPTION
TL;DR;
I found that my golang HTTP server serves markdown files with
`x-genesis-rom`. Documentation says that it consult `/etc/mime.types`,
which attributes md extension to `x-genesis-rom`.

I've checked freedesktop database and it has
```
/usr/share/mime/packages/freedesktop.org.xml:  <mime-type type="application/x-genesis-rom">
/usr/share/mime/application/x-genesis-rom.xml:<mime-type xmlns="http://www.freedesktop.org/standards/shared-mime-info" type="application/x-genesis-rom">
/usr/share/mime/globs:application/x-genesis-rom:*.smd
/usr/share/mime/globs:application/x-genesis-rom:*.gen
/usr/share/mime/globs2:50:application/x-genesis-rom:*.smd
/usr/share/mime/globs2:50:application/x-genesis-rom:*.gen
```

Therefor my change mostly sync mime.types with freedesktop.org DB