### PR TITLE
Fix regression for 04c9dae

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -334,6 +334,17 @@ if test -r /etc/profile.d/vte.sh -a ! -k /etc/profile.d/vte.sh; then
   . /etc/profile.d/vte.sh
 fi
 
+if test "$_is_save" = "unset" ; then
+    #
+    # Just in case the user excutes a command with ssh or sudo
+    #
+    if test \( -n "$SSH_CONNECTION" -o -n "$SUDO_COMMAND" \) -a -z "$PROFILEREAD" -a "$noprofile" != true ; then
+	_SOURCED_FOR_SSH=true
+	. /etc/profile > /dev/null 2>&1
+	unset _SOURCED_FOR_SSH
+    fi
+fi
+
 #
 # Set GPG_TTY for curses pinentry
 # (see man gpg-agent and bnc#619295)
@@ -356,14 +367,6 @@ esac
 test -s /etc/sh.shrc.local && . /etc/sh.shrc.local
 
 if test "$_is_save" = "unset" ; then
-    #
-    # Just in case the user excutes a command with ssh or sudo
-    #
-    if test \( -n "$SSH_CONNECTION" -o -n "$SUDO_COMMAND" \) -a -z "$PROFILEREAD" -a "$noprofile" != true ; then
-	_SOURCED_FOR_SSH=true
-	. /etc/profile > /dev/null 2>&1
-	unset _SOURCED_FOR_SSH
-    fi
     unset is _is_save
 fi
 

--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -340,8 +340,11 @@ if test "$_is_save" = "unset" ; then
     #
     if test \( -n "$SSH_CONNECTION" -o -n "$SUDO_COMMAND" \) -a -z "$PROFILEREAD" -a "$noprofile" != true ; then
 	_SOURCED_FOR_SSH=true
+	_is_save="$is"
 	. /etc/profile > /dev/null 2>&1
 	unset _SOURCED_FOR_SSH
+	is="$_is_save"
+        _is_save=unset
     fi
 fi
 


### PR DESCRIPTION
Move the ssh/sudo source of profile back to its original position, but unset 'is' and '_is_save' after checking for *.local files.

(bsc#1118364)