### PR TITLE
Make systemd detection cgroup oblivious (bsc#1140647)

### DIFF
--- a/files/usr/bin/chkconfig
+++ b/files/usr/bin/chkconfig
@@ -461,16 +461,8 @@ sub readable {
 # check if systemd is active
 #
 sub is_systemd_active {
-    my $cgroup_dev;
-    my $systemd_dev;
-    my $st;
-
     use File::stat;
-    $st = lstat("/sys/fs/cgroup") or return 0;
-    $cgroup_dev = $st->dev;
-    $st = lstat("/sys/fs/cgroup/systemd") or return 0;
-    $systemd_dev = $st->dev;
-    return 0 if ($cgroup_dev == $systemd_dev);
+    lstat("/run/systemd/system") or return 0;
     -e $systemd_binary_path or return 0;
     return 1;
 }

--- a/files/usr/sbin/service
+++ b/files/usr/sbin/service
@@ -7,7 +7,7 @@ VERSION="18.02.16"
 
 sd_booted()
 {
-    test -d /sys/fs/cgroup/systemd/
+    test -e /run/systemd/system/
 }
 
 #


### PR DESCRIPTION
systemd can work in three exclusive cgroup modes: legacy, hybrid and
unified. The mode affects where and what cgroup hierarchies are mounted.

Do not rely on that and detect running systemd as systemd itself does it
(src/libsystemd/sd-daemon/sd-daemon.c, function sd_booted).