### PR TITLE
Add support for lesskey.bin in /usr/etc

### DIFF
--- a/files/etc/csh.login
+++ b/files/etc/csh.login
@@ -166,6 +166,8 @@ if (! ${?LESS} ) then
     setenv LESS_ADVANCED_PREPROCESSOR "no"
     if ( -s /etc/lesskey.bin ) then
         setenv LESSKEY /etc/lesskey.bin
+    else if ( -s /usr/etc/lesskey.bin ) then
+        setenv LESSKEY /usr/etc/lesskey.bin
     endif
     setenv PAGER less
     setenv MORE -sl

--- a/files/etc/profile
+++ b/files/etc/profile
@@ -215,6 +215,8 @@ if test -z "$LESS" -a -x /usr/bin/less ; then
     LESS_ADVANCED_PREPROCESSOR="no"
     if test -s /etc/lesskey.bin ; then
 	LESSKEY=/etc/lesskey.bin
+    elif test -s /usr/etc/lesskey.bin ; then
+	LESSKEY=/usr/etc/lesskey.bin
     fi
     PAGER=less
     MORE=-sl


### PR DESCRIPTION
If /etc/lesskey.bin does not exist check for /usr/etc/lesskey.bin as fallback.