### PR TITLE
improve sysconf_addword

### DIFF
--- a/files/usr/sbin/sysconf_addword
+++ b/files/usr/sbin/sysconf_addword
@@ -55,6 +55,7 @@ add_word() {
 		sed -i -e "${lineno} { 
 			s/^[[:space:]]*\($var=\".*\)\(\".*\)/\1 $word_quoted\2/; 
 			s/=\"  */=\"/ 
+			s/ \+/ /g
 			}" $file
 		$debug && diff -u $tmpf $file
 	else
@@ -70,7 +71,8 @@ remove_word() {
 		$debug && cp $file $tmpf
 		sed -i -e "${lineno} { 
 			s/\(['\" 	]\)$word_quoted\(['\" 	]\)/\1 \2/g
-			s/  / /g
+			s/ \+/ /g
+			s/\ \+\(\"\)/\1/g
 			}" $file
 		$debug && diff -u $tmpf $file
 	else


### PR DESCRIPTION
remove/cleanup spaces while adding/removing flags/modules
e.g.:
removing `flag` from
`APACHE_SERVER_FLAGS="SSL flag"`
will result in
`APACHE_SERVER_FLAGS="SSL "` (space left over)
or
removing `flag` from
`APACHE_SERVER_FLAGS="SSL flag flag2"`
will result in
`APACHE_SERVER_FLAGS="SSL  flag2"` (double space between flags)

This patch will cleanup `spaces` to be only `single` or `none` ...