### PR TITLE
sysctl.d/50-default.conf: allow everybody to create IPPROTO_ICMP sock…

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -23,6 +23,14 @@ net.ipv4.conf.all.promote_secondaries = 1
 # (bsc#678066,bsc#752842,bsc#988023,bsc#990838)
 net.ipv6.conf.default.use_tempaddr = 1
 
+# allow all groups in the system to create IP sockets with
+# protocol == IPPROTO_ICMP. This makes it possible to use programs like ping
+# and fping to run without special permissions from capabilities or set*id
+# bits (bsc#1174504).
+# this only allows users to handle ICMP ECHO REQUESTs and REPLYs, nothing
+# else.
+net.ipv4.ping_group_range = "0 2147483647"
+
 # increase the number of possible inotify(7) watches
 fs.inotify.max_user_watches = 65536
 


### PR DESCRIPTION
…ets (bsc#1174504)

This will allows us to remove capability bits from `/usr/bin/ping` and
`/usr/sbin/pfing`. Furthermore other programs like `traceroute -I` start
working for regular users.

The ping_group_range allows to further limit the group IDs that are
allowed to use these sockets. It is difficult to find a sensible
limitation on a generic level, however. Daemons might just as well want
to send out pings as interactive users. Therefore all groups are allowed
by this configuration change.

The maximum group ID seems to be (2**31)-1, contrary to what a suggested
documentation snippet says, that never made into upstream [1].

[1]: https://lkml.org/lkml/2011/5/18/305