### PR TITLE
bashrc: fix bash: -s: command not found

### DIFF
--- a/files/etc/bash.bashrc
+++ b/files/etc/bash.bashrc
@@ -294,7 +294,7 @@ case "$-" in
     else
 	if test -s /etc/profile.d/alias.bash
 	then . /etc/profile.d/alias.bash
-	elif -s /usr/etc/profile.d/alias.bash
+	elif test -s /usr/etc/profile.d/alias.bash
 	then . /usr/etc/profile.d/alias.bash
 	fi
 	test -s $HOME/.alias && . $HOME/.alias


### PR DESCRIPTION
Issue introduced with 3f656fda7f