### PR TITLE
sysctl.d/50-default.conf: fix ping_group_range syntax error

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -29,7 +29,7 @@ net.ipv6.conf.default.use_tempaddr = 1
 # bits (bsc#1174504).
 # this only allows users to handle ICMP ECHO REQUESTs and REPLYs, nothing
 # else.
-net.ipv4.ping_group_range = "0 2147483647"
+net.ipv4.ping_group_range = 0 2147483647
 
 # increase the number of possible inotify(7) watches
 fs.inotify.max_user_watches = 65536


### PR DESCRIPTION
It turns out that sysctl passes on quotes to the proc pseudo file, so
remove them to fix this error:

```
sysctl: setting key "net.ipv4.ping_group_range": Invalid argument
```