### PR TITLE
Fix /etc/inputrc{,.keys}

### DIFF
--- a/files/etc/inputrc
+++ b/files/etc/inputrc
@@ -56,18 +56,18 @@ $if term=xterm
 "\e\eOC":	forward-word
 "\e\eOA":	previous-history
 "\e\eOB":	next-history
-"\C-\eOD":	backward-char
-"\C-\eOC":	forward-char
-"\C-\eOA":	previous-history
-"\C-\eOB":	next-history
-"\M-\eOD":	backward-word
-"\M-\eOC":	forward-word
-"\M-\eOA":	previous-history
-"\M-\eOB":	next-history
-"\C-\M-OD":	backward-char
-"\C-\M-OC":	forward-char
-"\C-\M-OA":	previous-history
-"\C-\M-OB":	next-history
+"\eOD":	backward-char
+"\eOC":	forward-char
+"\eOA":	previous-history
+"\eOB":	next-history
+"\e\217D":	backward-word
+"\e\217C":	forward-word
+"\e\217A":	previous-history
+"\e\217B":	next-history
+"\217D":	backward-char
+"\217C":	forward-char
+"\217A":	previous-history
+"\217B":	next-history
 $endif
 #
 # Standard cursor
@@ -76,18 +76,18 @@ $endif
 "\e\e[C":	forward-word
 "\e\e[A":	previous-history
 "\e\e[B":	next-history
-"\C-\e[D":	backward-char
-"\C-\e[C":	forward-char
-"\C-\e[A":	previous-history
-"\C-\e[B":	next-history
-"\M-\e[D":	backward-word
-"\M-\e[C":	forward-word
-"\M-\e[A":	previous-history
-"\M-\e[B":	next-history
-"\C-\M-[D":	backward-char
-"\C-\M-[C":	forward-char
-"\C-\M-[A":	previous-history
-"\C-\M-[B":	next-history
+"\e[D":	backward-char
+"\e[C":	forward-char
+"\e[A":	previous-history
+"\e[B":	next-history
+"\e\233D":	backward-word
+"\e\233C":	forward-word
+"\e\233A":	previous-history
+"\e\233B":	next-history
+"\233D":	backward-char
+"\233C":	forward-char
+"\233A":	previous-history
+"\233B":	next-history
 $endif
 #
 # end

--- a/files/etc/inputrc
+++ b/files/etc/inputrc
@@ -60,14 +60,15 @@ $if term=xterm
 "\eOC":	forward-char
 "\eOA":	previous-history
 "\eOB":	next-history
-"\e\217D":	backward-word
-"\e\217C":	forward-word
-"\e\217A":	previous-history
-"\e\217B":	next-history
-"\217D":	backward-char
-"\217C":	forward-char
-"\217A":	previous-history
-"\217B":	next-history
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\e\217D":	backward-word
+# "\e\217C":	forward-word
+# "\e\217A":	previous-history
+# "\e\217B":	next-history
+# "\217D":	backward-char
+# "\217C":	forward-char
+# "\217A":	previous-history
+# "\217B":	next-history
 $endif
 #
 # Standard cursor
@@ -80,14 +81,15 @@ $endif
 "\e[C":	forward-char
 "\e[A":	previous-history
 "\e[B":	next-history
-"\e\233D":	backward-word
-"\e\233C":	forward-word
-"\e\233A":	previous-history
-"\e\233B":	next-history
-"\233D":	backward-char
-"\233C":	forward-char
-"\233A":	previous-history
-"\233B":	next-history
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\e\233D":	backward-word
+# "\e\233C":	forward-word
+# "\e\233A":	previous-history
+# "\e\233B":	next-history
+# "\233D":	backward-char
+# "\233C":	forward-char
+# "\233A":	previous-history
+# "\233B":	next-history
 $endif
 #
 # end

--- a/files/etc/inputrc.keys
+++ b/files/etc/inputrc.keys
@@ -18,76 +18,52 @@ $if mode=emacs
 set editing-mode vi
     set keymap vi-command
     "\e[2~":	vi-editing-mode
-    "\M-[2~":	vi-editing-mode
     "\2332~":	vi-editing-mode
     set keymap vi-insert
     "\e[2~":	vi-replace
-    "\M-[2~":	vi-replace
     "\2332~":	vi-replace
 set editing-mode emacs
     set keymap emacs
     "\e[2~":	overwrite-mode
-    "\M-[2~":	overwrite-mode
     "\2332~":	overwrite-mode
 $endif
 "\e[3~":	delete-char
 "\e[4~":	end-of-line
 "\e[5~":	history-search-backward
 "\e[6~":	history-search-forward
-"\M-[1~":	beginning-of-line
-"\M-[3~":	delete-char
-"\M-[4~":	end-of-line
-"\M-[5~":	history-search-backward
-"\M-[6~":	history-search-forward
 "\2331~":	beginning-of-line
 "\2333~":	delete-char
 "\2334~":	end-of-line
 "\2335~":	history-search-backward
 "\2336~":	history-search-forward
 #
-# Cursor keys
-#
-"\e[C":		forward-char
-"\e[D":		backward-char
-"\e[A":		previous-history
-"\e[B":		next-history
-"\217C":	forward-char
-"\217D":	backward-char
-"\217A":	previous-history
-"\217B":	next-history
-"\233C":	forward-char
-"\233D":	backward-char
-"\233A":	previous-history
-"\233B":	next-history
-#
 # Cursor keys in keypad mode
 #
-"\C-[OD":       backward-char
-"\C-[OC":       forward-char
-"\C-[OA":       previous-history
-"\C-[OB":       next-history
+"\eOD":       backward-char
+"\eOC":       forward-char
+"\eOA":       previous-history
+"\eOB":       next-history
 #
 # Cursor keys in ANSI mode
 #
-"\C-[[D":       backward-char
-"\C-[[C":       forward-char
-"\C-[[A":       previous-history
-"\C-[[B":       next-history
+"\e[D":       backward-char
+"\e[C":       forward-char
+"\e[A":       previous-history
+"\e[B":       next-history
 #
 # Cursor keys in 8 bit keypad mode
 #
-"\C-\M-OD":      backward-char
-"\C-\M-OC":      forward-char
-"\C-\M-OA":      previous-history
-"\C-\M-OB":      next-history
+"\217D":      backward-char
+"\217C":      forward-char
+"\217A":      previous-history
+"\217B":      next-history
 #
 # Cursor keys in 8 bit ANSI mode
 #
-"\C-\M-[D":      backward-char
-"\C-\M-[C":      forward-char
-"\C-\M-[A":      previous-history
-"\C-\M-[B":      next-history
-"\C-^[[D":      backward-char
+"\233D":      backward-char
+"\233C":      forward-char
+"\233A":      previous-history
+"\233B":      next-history
 $if term=xterm
 $if mode=emacs
 # Note that this file is included for vi-command, vi-insert, and

--- a/files/etc/inputrc.keys
+++ b/files/etc/inputrc.keys
@@ -18,24 +18,28 @@ $if mode=emacs
 set editing-mode vi
     set keymap vi-command
     "\e[2~":	vi-editing-mode
-    "\2332~":	vi-editing-mode
+    # [Note: raw C1 chars conflicts with UTF-8]
+    # "\2332~":	vi-editing-mode
     set keymap vi-insert
     "\e[2~":	vi-replace
-    "\2332~":	vi-replace
+    # [Note: raw C1 chars conflicts with UTF-8]
+    # "\2332~":	vi-replace
 set editing-mode emacs
     set keymap emacs
     "\e[2~":	overwrite-mode
-    "\2332~":	overwrite-mode
+    # [Note: raw C1 chars conflicts with UTF-8]
+    # "\2332~":	overwrite-mode
 $endif
 "\e[3~":	delete-char
 "\e[4~":	end-of-line
 "\e[5~":	history-search-backward
 "\e[6~":	history-search-forward
-"\2331~":	beginning-of-line
-"\2333~":	delete-char
-"\2334~":	end-of-line
-"\2335~":	history-search-backward
-"\2336~":	history-search-forward
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\2331~":	beginning-of-line
+# "\2333~":	delete-char
+# "\2334~":	end-of-line
+# "\2335~":	history-search-backward
+# "\2336~":	history-search-forward
 #
 # Cursor keys in keypad mode
 #
@@ -53,17 +57,19 @@ $endif
 #
 # Cursor keys in 8 bit keypad mode
 #
-"\217D":      backward-char
-"\217C":      forward-char
-"\217A":      previous-history
-"\217B":      next-history
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\217D":      backward-char
+# "\217C":      forward-char
+# "\217A":      previous-history
+# "\217B":      next-history
 #
 # Cursor keys in 8 bit ANSI mode
 #
-"\233D":      backward-char
-"\233C":      forward-char
-"\233A":      previous-history
-"\233B":      next-history
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\233D":      backward-char
+# "\233C":      forward-char
+# "\233A":      previous-history
+# "\233B":      next-history
 $if term=xterm
 $if mode=emacs
 # Note that this file is included for vi-command, vi-insert, and
@@ -163,41 +169,42 @@ $if term=xterm
 "\e[1;8D":	backward-word
 "\e[1;8A":	history-search-backward
 "\e[1;8B":	history-search-forward
-"\2332C":	forward-word
-"\2332D":	backward-word
-"\2332A":	history-search-backward
-"\2332B":	history-search-forward
-"\2331;2C":	forward-word
-"\2331;2D":	backward-word
-"\2331;2A":	history-search-backward
-"\2331;2B":	history-search-forward
-"\2331;3C":	forward-word
-"\2331;3D":	backward-word
-"\2331;3A":	history-search-backward
-"\2331;3B":	history-search-forward
-"\2331;4C":	forward-word
-"\2331;4D":	backward-word
-"\2331;4A":	history-search-backward
-"\2331;4B":	history-search-forward
-"\2335C":	forward-word
-"\2335D":	backward-word
-"\2335A":	history-search-backward
-"\2335B":	history-search-forward
-"\2331;5C":	forward-word
-"\2331;5D":	backward-word
-"\2331;5A":	history-search-backward
-"\2331;5B":	history-search-forward
-"\2331;6C":	forward-word
-"\2331;6D":	backward-word
-"\2331;6A":	history-search-backward
-"\2331;6B":	history-search-forward
-"\2331;7C":	forward-word
-"\2331;7D":	backward-word
-"\2331;7A":	history-search-backward
-"\2331;7B":	history-search-forward
-"\2331;8C":	forward-word
-"\2331;8D":	backward-word
-"\2331;8A":	history-search-backward
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\2332C":	forward-word
+# "\2332D":	backward-word
+# "\2332A":	history-search-backward
+# "\2332B":	history-search-forward
+# "\2331;2C":	forward-word
+# "\2331;2D":	backward-word
+# "\2331;2A":	history-search-backward
+# "\2331;2B":	history-search-forward
+# "\2331;3C":	forward-word
+# "\2331;3D":	backward-word
+# "\2331;3A":	history-search-backward
+# "\2331;3B":	history-search-forward
+# "\2331;4C":	forward-word
+# "\2331;4D":	backward-word
+# "\2331;4A":	history-search-backward
+# "\2331;4B":	history-search-forward
+# "\2335C":	forward-word
+# "\2335D":	backward-word
+# "\2335A":	history-search-backward
+# "\2335B":	history-search-forward
+# "\2331;5C":	forward-word
+# "\2331;5D":	backward-word
+# "\2331;5A":	history-search-backward
+# "\2331;5B":	history-search-forward
+# "\2331;6C":	forward-word
+# "\2331;6D":	backward-word
+# "\2331;6A":	history-search-backward
+# "\2331;6B":	history-search-forward
+# "\2331;7C":	forward-word
+# "\2331;7D":	backward-word
+# "\2331;7A":	history-search-backward
+# "\2331;7B":	history-search-forward
+# "\2331;8C":	forward-word
+# "\2331;8D":	backward-word
+# "\2331;8A":	history-search-backward
 $else
 "\e[G":		re-read-init-file
 $endif
@@ -227,12 +234,13 @@ $if term=xterm
 "\e[4~":	set-mark
 "\e[H":		beginning-of-line
 "\e[F":		end-of-line
-"\2171~":	history-search-backward
-"\2174~":	set-mark
-"\217H":	beginning-of-line
-"\217F":	end-of-line
-"\233H":	beginning-of-line
-"\233F":	end-of-line
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\2171~":	history-search-backward
+# "\2174~":	set-mark
+# "\217H":	beginning-of-line
+# "\217F":	end-of-line
+# "\233H":	beginning-of-line
+# "\233F":	end-of-line
 "\e[1;2H":	beginning-of-line
 "\e[1;2F":	end-of-line
 "\e[1;3H":	beginning-of-line
@@ -247,20 +255,21 @@ $if term=xterm
 "\e[1;7F":	end-of-line
 "\e[1;8H":	beginning-of-line
 "\e[1;8F":	end-of-line
-"\2331;2H":	beginning-of-line
-"\2331;2F":	end-of-line
-"\2331;3H":	beginning-of-line
-"\2331;3F":	end-of-line
-"\2331;4H":	beginning-of-line
-"\2331;4F":	end-of-line
-"\2331;5H":	beginning-of-line
-"\2331;5F":	end-of-line
-"\2331;6H":	beginning-of-line
-"\2331;6F":	end-of-line
-"\2331;7H":	beginning-of-line
-"\2331;7F":	end-of-line
-"\2331;8H":	beginning-of-line
-"\2331;8F":	end-of-line
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\2331;2H":	beginning-of-line
+# "\2331;2F":	end-of-line
+# "\2331;3H":	beginning-of-line
+# "\2331;3F":	end-of-line
+# "\2331;4H":	beginning-of-line
+# "\2331;4F":	end-of-line
+# "\2331;5H":	beginning-of-line
+# "\2331;5F":	end-of-line
+# "\2331;6H":	beginning-of-line
+# "\2331;6F":	end-of-line
+# "\2331;7H":	beginning-of-line
+# "\2331;7F":	end-of-line
+# "\2331;8H":	beginning-of-line
+# "\2331;8F":	end-of-line
 "\e[2H":	beginning-of-line
 "\e[2F":	end-of-line
 "\e[5H":	beginning-of-line
@@ -294,7 +303,8 @@ $if term=xterm
 "\eOA":         previous-history
 "\eOB":         next-history
 "\eOE":         re-read-init-file
-"\217E":	re-read-init-file
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\217E":	re-read-init-file
 "\eO2D":        backward-word
 "\eO2C":        forward-word
 "\eO2A":        history-search-backward
@@ -385,10 +395,11 @@ $if term=xterm
 "\eO1;8Q":	undo
 "\eO1;8R":	""  
 "\eO1;8S":	kill-line
-"\217P":	"\e"
-"\217Q":	undo
-"\217R":	""  
-"\217S":	kill-line
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\217P":	"\e"
+# "\217Q":	undo
+# "\217R":	""  
+# "\217S":	kill-line
 $endif
 $if term=gnome
 # or gnome terminal F1 - F4
@@ -418,7 +429,8 @@ $else
 "\e[13~":	""
 "\e[14~":	kill-line
 "\e[15~":	""
-"\23315~":	""
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\23315~":	""
 $endif
 "\e[17~":	""
 "\e[18~":	""
@@ -439,23 +451,24 @@ $endif
 "\e[34~":	""
 "\e[35~":	""
 "\e[36~":	""
-"\23317~":	""
-"\23318~":	""
-"\23319~":	""
-"\23320~":	""
-"\23321~":	""
-"\23323~":	""
-"\23324~":	""
-"\23325~":	""
-"\23326~":	""
-"\23328~":	""
-"\23329~":	""
-"\23331~":	""
-"\23332~":	""
-"\23333~":	""
-"\23334~":	""
-"\23335~":	""
-"\23336~":	""
+# [Note: raw C1 chars conflicts with UTF-8]
+# "\23317~":	""
+# "\23318~":	""
+# "\23319~":	""
+# "\23320~":	""
+# "\23321~":	""
+# "\23323~":	""
+# "\23324~":	""
+# "\23325~":	""
+# "\23326~":	""
+# "\23328~":	""
+# "\23329~":	""
+# "\23331~":	""
+# "\23332~":	""
+# "\23333~":	""
+# "\23334~":	""
+# "\23335~":	""
+# "\23336~":	""
 $if term=xterm
 "\e[1;2P":	""
 "\e[1;2Q":	""
@@ -567,25 +580,26 @@ $if term=xterm
 "\eOw":		"7"
 "\eOx":		"8"
 "\eOy":		"9"
-# Operators
-"\217o":	"/"
-"\217j":	"*"
-"\217m":	"-"
-"\217k":	"+"
-"\217l":	","
-"\217M":	accept-line
-"\217n":	"."
-# Numbers
-"\217p":	"0"
-"\217q":	"1"
-"\217r":	"2"
-"\217s":	"3"
-"\217t":	"4"
-"\217u":	"5"
-"\217v":	"6"
-"\217w":	"7"
-"\217x":	"8"
-"\217y":	"9"
+# [Note: raw C1 chars conflicts with UTF-8]
+# # Operators
+# "\217o":	"/"
+# "\217j":	"*"
+# "\217m":	"-"
+# "\217k":	"+"
+# "\217l":	","
+# "\217M":	accept-line
+# "\217n":	"."
+# # Numbers
+# "\217p":	"0"
+# "\217q":	"1"
+# "\217r":	"2"
+# "\217s":	"3"
+# "\217t":	"4"
+# "\217u":	"5"
+# "\217v":	"6"
+# "\217w":	"7"
+# "\217x":	"8"
+# "\217y":	"9"
 $endif
 #
 $if term=kterm


### PR DESCRIPTION
@bitstreamout Is this the right place to suggest changes in `/etc/inputrc{,.keys}`? Following the code comment at the top of `/etc/inputrc`, here I submit a PR. There are two types of issues with the current `/etc/inputrc` and `/etc/inputrc.keys`:

- Some key sequences are specified in a wrong format. Also, there are duplicate keybindings, i.e., keybindings with multiple different representations of *an identical key sequence* are defined.
- The keybindings to raw 8-bit C1 characters conflict with UTF-8 encoding.

### Incorrect key-sequence format

Currently, some key sequences are specified in incorrect formats. Here are the examples:

#### 1. `\C-\eOD` (`/etc/inputrc`)

This is interpreted as `^\` (Control-Backslash = FS) + `e` + `O` + `D` until Readline 8.0. This is interpreted as `\e` (ESC) + `O` + `D` in Readline 8.1+.  <kbd>FS e O D</kbd> doesn't make sense, so I guess the intended key sequences here is <kbd>ESC O D</kbd> (7-bit representation of <kbd>SS3 D</kbd>). However, the keybindings of these key sequences are already defined.

#### 2. `\M-\eOD` (`/etc/inputrc`)

This is interpreted as `M-\` (Meta-Backslash = raw `Ü`) + `e` + `O` + `D` until Readline 8.0. This is interpreted as `\233` (raw CSI)+ `O` + `D`  in Readline 8.1+. Neither <kbd>Ü e O D</kbd> nor <kbd>CSI O D</kbd> doesn't make sense as a key sequence. I guess the original intent is `\e\217D` <kbd>ESC SS3 D</kbd>. However, the keybindings of these key sequences are already defined.

#### 3. `\C-\M-OD` (`/etc/inputrc`)

This is interpreted as `\e` (ESC) + `^O` (Control-O) + `D` until Readline 8.0. This is interpreted as `\217` (raw SS3) + `D` in Readline 8.1+. I guess the original intent is `\217D` as in Readline 8.1+. However, the keybindings of these key sequences are already defined.

#### 4. `\M-[2~` (`/etc/inputrc.keys`)

This is interpreted as `M-[` (Meta-Left-Bracket = raw `Û`)+ `2` `~`. This is interpreted as `\e` + `[` + `2` + `~` only when `set convert-meta on`, but `convert-meta` is turned off at the beginning of `/etc/inputrc`. <kbd>Û 2 ~</kbd> doesn't make sense as a key sequence. I guess the intent is `\e[2~`, but the corresponding keybindings are already registered.

#### 5. `\C-\M-[D` (`/etc/inputrc.keys`)

This is interpreted as `\e` (ESC) + `\e` (ESC = C-[) + `D` until Readline 8.0. This is interpreted as `\233` (raw CSI) + `D` in Readline 8.1+. I guess this is intended to be `\233D`.

#### 6. `\C-^[[D` (`/etc/inputrc.keys`)

This is interpreted as `^^` (Control-circumflex) + `[` + `[` + `D` which doesn't make sense as a key sequence. I guess this is intended to be `\e[D` (`\C-\C-[` + `[` + `D` = `\e` + `[` + `D`).

I have adjusted these key sequences, and also removed duplicate keybindings in the commit ba286f5.

### Conflicts with UTF-8

The keybindings that involve raw 8-bit C1 characters---specifically, `\233` (raw <kbd>CSI</kbd>) and `\217` (raw <kbd>SS3</kbd>)---conflict with UTF-8 encoding. These bytes `\233` and `\217` are used in the second or later bytes in the multibyte representation of UTF-8. Because these raw 8-bit C1 characters are directly used in the keybindings such as `\233A` or `\233F`, **it is now impossible to input some combinations of Unicode strings**, e.g. "ΛC", "力F", "子供A", because of these UTF-8 violating keybindings.

- First of all, this 8-bit representation of C1 characters is rarely used today. Even the terminal emulators with the 8-bit C1 support use 7-bit representation by default and only use the 8-bit representation when requested by the terminal application using <kbd>S8C1T</kbd> (`\e G`). And, for the application side, there is no reason to request the 8-bit representation because it cannot expect the 8-bit C1 support by all the terminals while it can expect the 7-bit C1 support.
- Next, the 8-bit representation of C1 characters is not always transmitted with raw bytes but, depending on the terminal implementation, may be encoded using the UTF-8 scheme when the terminal is working with `LC_CTYPE=*.UTF-8`. For example <kbd>CSI</kbd> U+009B should be encoded as `\302\233` in UTF-8. <kbd>SS3</kbd> U+008F should be encoded as `\302\217` in UTF-8. To avoid conflicts in UTF-8 encoding, 8-bit C1 characters should be encoded by the UTF-8 scheme. However, in reality, many terminals still use raw C1 characters, but only a small number of terminals use UTF-8 encoded 8-bit C1 characters.
- `/etc/inputrc{,.keys}` cannot be configured so as to switch key bindings depending on `LC_CTYPE`, so it should not contain the encoding dependent keybindings.

For these reasons, the keybindings involving `\233` and `\217` (which are inherently ambiguous, rarely used, and conflicting with UTF-8) are now commented out (ad4f969). Maybe these lines can be completely deleted. Or, maybe these lines can be converted to use the UTF-8 encoded 8-bit C1 characters instead of raw ones. If there is any suggestion, I can edit the commit.

