### PR TITLE
excluding new kernel string in version search

### DIFF
--- a/get_kernel_version.c
+++ b/get_kernel_version.c
@@ -116,7 +116,7 @@ main (int argc, char *argv[])
 	    buffer[i+10] == 'i' && buffer[i+11] == 'o' &&
 	    buffer[i+12] == 'n' && buffer[i+13] == ' ' &&
 	    /* current s390 images have that string without version: */
-	    buffer[i+14] != 0)
+	    buffer[i+14] != 0 && buffer[i+17] != 0)
           {
 	    int j = i+14;
 	    int number_dots = 0;


### PR DESCRIPTION
s390x image file now contains a string like:

Linux version %s

This should of course be omitted in get_kernel_version. Since no valid kernel version will end the string at position 17, it should be safe to just ignore strings that end at that position. See also boo#1183037.