### PR TITLE
Verify that locale set by SSH is valid, else use system default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ CFLAGS=-O2 -g -Wall
 CPPFLAGS=-D_FILE_OFFSET_BITS=64
 LDFLAGS=-Wl,-z,relro,-z,now
 
-bin_PROGRAMS=get_kernel_version
+bin_PROGRAMS=get_kernel_version locale-check
 
 all: $(bin_PROGRAMS)
 
 install: all
 	cp -a files/* $(DESTDIR)/
 	install -m755 get_kernel_version $(DESTDIR)/usr/bin
+	install -m755 locale-check $(DESTDIR)/usr/bin
 
 clean:
 	rm -f $(bin_PROGRAMS)

--- a/files/usr/etc/profile.d/ssh-locale-check.sh
+++ b/files/usr/etc/profile.d/ssh-locale-check.sh
@@ -1,0 +1,14 @@
+#
+# locale-check.sh: Verify that the locale SSH did set is valid,
+#                  else reset to the system default.
+#
+
+# Only check locale if it did got set by SSH
+test -z "$SSH_SENDS_LOCALE" && return
+
+_SYSTEM_DEFAULT_LANG=C.UTF-8
+if [ -s /etc/locale.conf ]; then
+    eval "$(sed -rn -e 's/^(LANG)=/_SYSTEM_DEFAULT_\1=/p' < /etc/locale.conf)"
+fi
+# Make sure the locale variables are set to valid values.
+eval "$(/usr/bin/locale-check ${_SYSTEM_DEFAULT_LANG})"

--- a/locale-check.c
+++ b/locale-check.c
@@ -1,0 +1,82 @@
+/* From base-files-11ubuntu5.1 */
+
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *help = "locale-check DEFAULT_LOCALE\n"
+	"\n"
+	"Check that the various locale-related environment variables contain\n"
+	"values that can be set. Output shell that can be passed to eval to\n"
+	"set any invalid environment variables to DEFAULT_LOCALE\n";
+
+static void usage(void) {
+	fprintf(stderr, "%s", help);
+	exit(1);
+}
+
+static void check(int category, char* varname, char* defvalue) {
+	if (getenv(varname) != NULL) {
+		if (setlocale(category, "") == NULL) {
+			printf("%s=%s\n", varname, defvalue);
+		}
+	}
+}
+
+#define SINGLEQUOTE '\''
+#define BACKSLASH   '\\'
+
+/* Quote 'val' for shell */
+static char *quote(char* val) {
+	/* This implementation single quotes val and replaces single quotes
+	   with SINGLEQUOTE BACKSLASH SINGLEQUOTE SINGLEQUOTE. The worst
+	   case is that val is entirely single quotes, in which case each
+	   character of the input becomes 4 bytes. Then 3 bytes for
+	   surrounding quotes and terminating NUL. */
+	char *ret = malloc(strlen(val)*4+3);
+	char *source = val;
+	char *dest = ret;
+
+	*dest++ = SINGLEQUOTE;
+	while (*source) {
+		if (*source == SINGLEQUOTE) {
+			*dest++ = SINGLEQUOTE;
+			*dest++ = BACKSLASH;
+			*dest++ = SINGLEQUOTE;
+		}
+		*dest++ = *source++;
+	}
+	*dest++ = SINGLEQUOTE;
+	*dest++ = 0;
+	return ret;
+}
+
+#define CHECK(cat, def) check(cat, #cat, def);
+
+int main(int argc, char** argv) {
+	char *defval;
+	if (argc != 2) {
+		usage();
+	}
+	defval = quote(argv[1]);
+	/* setlocale will never consult LANG if LC_ALL is set */
+	if (getenv("LC_ALL") == NULL) {
+		check(LC_ALL, "LANG", defval);
+	} else {
+		CHECK(LC_ALL, defval);
+	}
+	CHECK(LC_ADDRESS, defval);
+	CHECK(LC_COLLATE, defval);
+	CHECK(LC_CTYPE, defval);
+	CHECK(LC_IDENTIFICATION, defval);
+	CHECK(LC_MEASUREMENT, defval);
+	CHECK(LC_MESSAGES, defval);
+	CHECK(LC_MONETARY, defval);
+	CHECK(LC_NAME, defval);
+	CHECK(LC_NUMERIC, defval);
+	CHECK(LC_PAPER, defval);
+	CHECK(LC_TELEPHONE, defval);
+	CHECK(LC_TIME, defval);
+	return 0;
+}


### PR DESCRIPTION
Verify that the locale SSH did set is valid, else reset to the system default.

Other Linux distros have this since ages, we use it since a very long time on MicroOS (as we only have two locales), but I think this could be useful for all kind of our OS flavors.