### PR TITLE
Stop lowering the inotify limit

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -34,8 +34,8 @@ net.ipv6.conf.default.use_tempaddr = 1
 # else.
 -net.ipv4.ping_group_range = 0 2147483647
 
-# increase the number of possible inotify(7) watches
-fs.inotify.max_user_watches = 65536
+# increase the number of possible inotify(7) user instances
+fs.inotify.max_user_instances = 8192
 
 # Magic SysRq Keys enable some control over the system even if it
 # crashes (e.g. during kernel debugging).


### PR DESCRIPTION
Since https://github.com/torvalds/linux/commit/92890123749bafc317bbfacbe0a62ce08d78efb7
the linux kernel actually choses a sane default, and we're lowering
it here.

Instead increase the user_instances which is needed for running
dapper/containerd workload, see https://www.suse.com/support/kb/doc/?id=000020048