### PR TITLE
Don't enable lastlog by default

### DIFF
--- a/aaa_base.post
+++ b/aaa_base.post
@@ -42,7 +42,6 @@ while read file owner mode; do
     chown "$owner" "$file"
 done <<EOT
 /root/.bash_history root:root 600
-/var/log/lastlog    root:root 644
 EOT
 
 exit 0


### PR DESCRIPTION
lastlog is not Y2038 safe, not even on 64bit architectures. And since very few tools support /var/log/lastlog, the data is of limited use. On Desktop systems the output is nearly everytime wrong.