### PR TITLE
Replace /bin/bash shebangs with /bin/sh

### DIFF
--- a/aaa_base.post
+++ b/aaa_base.post
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #
 # post.sh - to be done after extraction

--- a/files/usr/bin/old
+++ b/files/usr/bin/old
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # This script simply renames files or directories to <name>-<date>[<num>]

--- a/files/usr/bin/safe-rm
+++ b/files/usr/bin/safe-rm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 todo=
 opts=

--- a/files/usr/sbin/refresh_initrd
+++ b/files/usr/sbin/refresh_initrd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Refresh initrd depending on conditions.
 # Currently only the change of /etc/sysconfig/clock is

--- a/files/usr/sbin/service
+++ b/files/usr/sbin/service
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # /sbin/service		Handle boot and runlevel services
 #

--- a/files/usr/sbin/smart_agetty
+++ b/files/usr/sbin/smart_agetty
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # emulate: /sbin/agetty -L $speed console for console != vga/framebuffer console
 
 #echo "$0: called with '$*'" > /dev/kmsg

--- a/files/usr/sbin/sysconf_addword
+++ b/files/usr/sbin/sysconf_addword
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2005 Peter Poeml <apache@suse.de>. All Rights Reserved.
 


### PR DESCRIPTION
The freedom to choose shell might be crucial for embedded projects where GPLv3 license is not allowed.