### PR TITLE
Make shell scripts bash-independent

### DIFF
--- a/aaa_base.post
+++ b/aaa_base.post
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #
 # post.sh - to be done after extraction

--- a/files/usr/bin/old
+++ b/files/usr/bin/old
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # This script simply renames files or directories to <name>-<date>[<num>]
@@ -32,19 +32,19 @@ if [ "$1" = "-h" -o "$1" = "--help" ] ; then
     exit
 fi
 
-DATESTRING=`date +"%Y%m%d"`
+DATESTRING=$(date +"%Y%m%d")
 
 for i in "$@" ; do
-    i=${i%%/}
+    i=$(echo "$i" | sed 's/\/$//')
     if [ -e "$i" ] ; then
         NEWNAME=$i-$DATESTRING
         NUMBER=0
         while [ -e "$NEWNAME" ] ; do
             NEWNAME=$i-$DATESTRING-$NUMBER
-            let NUMBER=$NUMBER+1
+            NUMBER=$(expr $NUMBER + 1)
         done
         echo moving "$i" to "$NEWNAME"
-	if [ "${i:0:1}" = "-" ] ; then
+	if [ "$(echo $i | cut -c 1)" = "-" ] ; then
 	    i="./$i"
 	    NEWNAME="./$NEWNAME"
 	fi
@@ -53,4 +53,3 @@ for i in "$@" ; do
         echo "$i" does not exist.
     fi
 done
-

--- a/files/usr/bin/safe-rm
+++ b/files/usr/bin/safe-rm
@@ -1,24 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
 todo=
 opts=
-case "${0##*/}" in
+case "$(basename "$0")" in
     safe-rm)	todo=rm    ; opts=-f ;;
     safe-rmdir) todo=rmdir ; opts=   ;;
 esac
 
-set -o physical
 test -n "$todo"     || exit 2
 test -x /bin/$todo  || exit 2
 test -x /bin/pwd    || exit 2
 
 for d; do
-    if [[ "$d" != /* ]] ; then
+    if ! echo "$d" | grep -q "^/" ; then
 	echo "usage: $0 _absolute_path_to_file" 1>&2
 	exit 1
     fi
-    path=${d//\/.\//\/}
-    name=${path##*/}
+    path=$(echo "$d" | sed 's/\/\.\//\//g') 
+    name=$(basename "$path")
 
     if test "/$name" = "$path" ; then
 	echo "$0: usage in root directory not allowed" 1>&2
@@ -33,7 +32,7 @@ for d; do
 
     if cd -P "${path}" && test "${path}" = "$(pwd -P)" ; then
 
-	if test "$PWD" = "$(/bin/pwd)" ; then
+	if test "$(pwd -P)" = "$(/bin/pwd)" ; then
 	    /bin/$todo $opts -- "$name"
 	else
 	    echo "$0: no symlinks allowed in the path of $d" 1>&2

--- a/files/usr/sbin/refresh_initrd
+++ b/files/usr/sbin/refresh_initrd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Refresh initrd depending on conditions.
 # Currently only the change of /etc/sysconfig/clock is
@@ -14,28 +14,36 @@ refresh=no
 test /etc/sysconfig/clock  -nt $initrd && refresh=yes
 test /etc/sysconfig/kernel -nt $initrd && refresh=yes
 
-while read module ; do
+tmpfile=$(mktemp)
+
+lsinitrd $initrd | grep -E "$modules/.*\.ko" > "$tmpfile"
+
+while IFS= read -r module; do
     module=${module##*/}
     module=${module%.ko}
-    modconfs=$(grep -lE "[[:blank:]]$module[[:blank:]]" /etc/modprobe.d/*)
+    modconfs=$(grep -lE "[[:blank:]]${module}[[:blank:]]" /etc/modprobe.d/*)
     for modconf in $modconfs; do
-	test $modconf -nt $initrd && refresh=yes
-	break 2
+        test $modconf -nt $initrd && refresh=yes
+        break 2
     done
-done < <(lsinitrd /boot/initrd | grep -E "$modules/.*\.ko")
+done < "$tmpfile"
+rm "$tmpfile"
 unset modules module modconfs modconf
 
 test "$refresh" = yes || exit 0
 
-/sbin/modprobe dm_mod --quiet &> /dev/null || true
+/sbin/modprobe dm_mod --quiet > /dev/null 2>&1 || true
 
 line=on
 test -e /proc/splash && read line < /proc/splash
 line=${line##*: }
 
 SPLASH=no
-[[ $line =~ on ]] && SPLASH=yes
+case $line in
+    *on*) SPLASH=yes;;
+esac
 test -e /etc/sysconfig/bootsplash && . /etc/sysconfig/bootsplash
 
 test $SPLASH = yes && set -- -s auto
-exec -a mkinitrd /sbin/mkinitrd ${1+"$@"}
+exec /sbin/mkinitrd "${1+"$@"}"
+

--- a/files/usr/sbin/service
+++ b/files/usr/sbin/service
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # /sbin/service		Handle boot and runlevel services
 #
@@ -35,15 +35,17 @@ test -n "$SYSTEMD_NO_WRAP" && export SYSTEMD_NO_WRAP
 LANG=POSIX
 export PATH TERM LANG
 
-typeset -i reloaded=0
+reloaded=0
 daemon_reload()
 {
 	local state
-	((reloaded)) && return
+	if [ "$reloaded" -ne 0 ]; then
+        return
+    fi
 	state=$(systemctl --full --no-legend --no-pager --property=NeedDaemonReload show "$1" 2>/dev/null)
 	test "$state" = "NeedDaemonReload=no" && return
 	systemctl daemon-reload
-	let reloaded++
+	reloaded=$((reloaded + 1))
 }
 
 is_service()
@@ -69,7 +71,7 @@ is_systemd_action()
 exec_rc ()
 {
     local rc=''
-    local -i ret
+    local ret
     if sd_booted && test -z "$SYSTEMD_NO_WRAP"; then
 	if is_systemd_action "$2"; then
 		if is_service "$1"; then
@@ -176,17 +178,17 @@ full_restart=0
         args=""
 while test $# -gt 0; do
     opt=
-    if test "${1::1}" = "-"; then
-	if test ${#1} -gt 2 -a "${1::2}" = "--" ; then
-	    opt="${1:2}"
-	else
-	    opt="${1:1}"
-	fi
-	shift
+	if [ "$(echo "$1" | cut -c1)" = "-" ]; then
+        if [ "$(echo "$1" | cut -c1-2)" = "--" ] && [ "$(echo "$1" | cut -c3- | wc -c)" -gt 1 ]; then
+            opt="$(echo "$1" | cut -c3-)"
+        else
+            opt="$(echo "$1" | cut -c2-)"
+        fi
+        shift
     else
-	args="${args:+$args }$1"
-	shift
-	continue
+        args="${args:+$args }$1"
+        shift
+        continue
     fi
 
     case "$opt" in

--- a/files/usr/sbin/smart_agetty
+++ b/files/usr/sbin/smart_agetty
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # emulate: /sbin/agetty -L $speed console for console != vga/framebuffer console
 
 #echo "$0: called with '$*'" > /dev/kmsg

--- a/files/usr/sbin/sysconf_addword
+++ b/files/usr/sbin/sysconf_addword
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2005 Peter Poeml <apache@suse.de>. All Rights Reserved.
 
@@ -41,7 +41,8 @@ find_last_occurrence () {
 
 word_present () {
 	. $file
-	case " ${!var} " in
+	var_value="$(eval "echo \${$var}")"
+	case " $var_value " in
 	*" $word "*) true;;
 	*) false;;
 	esac
@@ -102,7 +103,7 @@ esac
 file=$1; shift
 var=$1; shift
 word=$1
-word_quoted=${1//\//\\\/}
+word_quoted=$(echo "$1" | sed 's/\//\\\//g')
 
 
 if $debug; then


### PR DESCRIPTION
The motivation is to be able to use the scripts in the environment free of GPLv3 licenses, which might be useful for embedded projects. 

My goal was to make it a bit closer to POSIX and fix most of warnings that `shellcheck --shell=sh` returns. However, some of them, like usage of `local` variables, are still there, as majority of shells support it nowadays. 

The changes have been tested with busybox sh. 