### PR TITLE
respect /etc/alternatives/java when setting JAVA_HOME

### DIFF
--- a/files/usr/etc/profile.d/alljava.csh
+++ b/files/usr/etc/profile.d/alljava.csh
@@ -9,7 +9,13 @@
 #                     JDK_HOME, SDK_HOME
 #
 
-foreach JDIR ( "/usr/lib64/jvm" "/usr/lib/jvm" "/usr/java/latest" "/usr/java" )
+set ALTERNATIVES_JAVA_HOME
+if ( -l /etc/alternatives/java ) then
+    set ALTERNATIVES_JAVA_LINK=`realpath /etc/alternatives/java`
+    set ALTERNATIVES_JAVA_HOME=$ALTERNATIVES_JAVA_LINK:h:h
+endif
+
+foreach JDIR ( $ALTERNATIVES_JAVA_HOME "/usr/lib64/jvm" "/usr/lib/jvm" "/usr/java/latest" "/usr/java" )
 
     if ( ! -d $JDIR ) continue
 

--- a/files/usr/etc/profile.d/alljava.sh
+++ b/files/usr/etc/profile.d/alljava.sh
@@ -9,7 +9,13 @@
 #                     JDK_HOME, SDK_HOME
 #
 
-for JDIR in /usr/lib64/jvm /usr/lib/jvm /usr/java/latest /usr/java; do
+if test -L /etc/alternatives/java
+then
+    ALTERNATIVES_JAVA_LINK=`realpath /etc/alternatives/java`
+    ALTERNATIVES_JAVA_HOME=${ALTERNATIVES_JAVA_LINK/\/bin\/java}
+fi
+
+for JDIR in $ALTERNATIVES_JAVA_HOME /usr/lib64/jvm /usr/lib/jvm /usr/java/latest /usr/java; do
 
     if ! test -d $JDIR; then
         continue


### PR DESCRIPTION
patch alljava.sh and alljava.csh along the patch from bug#1107342