### PR TITLE
Check for valid TERM

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -193,6 +193,8 @@ mkdir -p %{buildroot}%{_fillupdir}
 /usr/etc/profile.d/ls.tcsh
 /usr/etc/profile.d/ls.bash
 /usr/etc/profile.d/ls.zsh
+/usr/etc/profile.d/terminal.sh
+/usr/etc/profile.d/terminal.csh
 %dir /usr/lib/environment.d
 /usr/lib/environment.d/50-xdg.conf
 %config /etc/shells

--- a/files/usr/etc/profile.d/terminal.csh
+++ b/files/usr/etc/profile.d/terminal.csh
@@ -1,0 +1,5 @@
+# fallback in case TERM is unknown
+tput cols >& /dev/null
+if ( $? != 0 ) then
+    setenv TERM vt220
+endif

--- a/files/usr/etc/profile.d/terminal.sh
+++ b/files/usr/etc/profile.d/terminal.sh
@@ -1,0 +1,4 @@
+# fallback in case TERM is unknown
+if ! tput cols >/dev/null 2>&1; then
+    TERM=vt220
+fi


### PR DESCRIPTION
Fall back to vt220 if $TERM is invalid. Might happen when only terminfo-base is install.