### PR TITLE
Restrict ptrace with Yama LSM by default

### DIFF
--- a/files/usr/lib/sysctl.d/52-yama.conf
+++ b/files/usr/lib/sysctl.d/52-yama.conf
@@ -20,4 +20,4 @@
 #
 # The default value of ptrace_scope is 1. Any value other than 0 will break some
 # legitimate usecases.
--kernel.yama.ptrace_scope = 0
+-kernel.yama.ptrace_scope = 1


### PR DESCRIPTION
This prevents e.g. snooping on ssh sessions.