### PR TITLE
drop obsolete 50-default-s390.conf (bsc#1211721)

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -112,10 +112,6 @@ systems.
 %install
 %make_install
 mkdir -p %{buildroot}/etc/sysctl.d
-case "$RPM_ARCH" in
-	s390*) ;;
-	*) rm -f %{buildroot}/usr/lib/sysctl.d/50-default-s390.conf ;;
-esac
 #
 # make sure it does not creep in again
 test -d %{buildroot}/root/.gnupg && exit 1

--- a/files/usr/lib/sysctl.d/50-default-s390.conf
+++ b/files/usr/lib/sysctl.d/50-default-s390.conf
@@ -1,5 +1,0 @@
-# performance tuning for s390(x)
-kernel.sched_min_granularity_ns = 10000000
-kernel.sched_wakeup_granularity_ns = 15000000
-kernel.sched_latency_ns = 80000000
-kernel.sched_tunable_scaling = 0


### PR DESCRIPTION
systcl settings that have been changed in the kernel ages ago