### PR TITLE
Remove kernel.pid_max limit (bsc#1219038)

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -56,6 +56,10 @@ fs.inotify.max_user_instances = 8192
 # default 184 = 128+32+16+8
 kernel.sysrq = 184
 
+# Remove pid_max limit by setting maximum possible value
+# (bsc#1219038,  https://www.suse.com/support/kb/doc/?id=000020429)
+kernel.pid_max = 4194304
+
 # enable hard- and symlink protection (bnc#821585)
 fs.protected_hardlinks = 1
 fs.protected_symlinks = 1


### PR DESCRIPTION
kernel.pid_max is one of multiple mechanisms to restrict number of processes [1]. Its kernel default is scaled with nr_cpus but 1024 tasks/cpu cap is too much if they were all running and it is also too little when they are idle (memory being bottleneck).

Bump the limit to maximum kernel-accepted value and defer to other mechanisms for tasks limit enforcing.

(This way we converge to same config like upstream systemd [2] but we ship distro defaults together from this package.)

### SLE packaging intentions

( Cc: @bugfinder )
* this change should eventually end up in `SUSE:SLFO:Main/aaa_base` (future SLE)
* at the same time, it should not be picked by existing products (like `SUSE:SLE-15-SP3:Update`)

[1] https://www.suse.com/support/kb/doc/?id=000020429
[2] https://github.com/systemd/systemd/blob/72192b6cc9b856c10abc7f1e5f98240fde17b8b4/sysctl.d/50-pid-max.conf