### PR TITLE
Add tmpfiles.d/soft-reboot-cleanup.conf

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -193,6 +193,7 @@ mkdir -p %{buildroot}%{_fillupdir}
 /usr/etc/profile.d/terminal.csh
 %dir /usr/lib/environment.d
 /usr/lib/environment.d/50-xdg.conf
+%{_tmpfilesdir}/soft-reboot-cleanup.conf
 %config /etc/shells
 %ghost %dir /etc/init.d
 %ghost %config(noreplace) /etc/init.d/boot.local

--- a/files/usr/lib/tmpfiles.d/soft-reboot-cleanup.conf
+++ b/files/usr/lib/tmpfiles.d/soft-reboot-cleanup.conf
@@ -1,0 +1,5 @@
+# This config makes sure that special files in /run get's deleted
+# after a soft-reboot. Normally this would happen automatically with
+# a real reboot since /run is on tmpfs, but with a soft-reboot, /run
+# will survive and we have to cleanup ourself.
+r /run/reboot-needed


### PR DESCRIPTION
Currently tmpfiles.d/soft-reboot-cleanup.conf is part of rebootmgr. But since the problem is generic to every product, independent of if using rebootmgr or not, it should be part of aaa_base.

The problem is, that `systemctl soft-reboot` will not clear `/run` and thus all tools assume a reboot is still necessary. I expect that over the time we will add more files and directories.