### PR TITLE
Remove legacy-actions support [jsc#PED-264]

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -132,8 +132,6 @@ mkdir -p %{buildroot}/etc/init.d
 for i in boot.local after.local ; do
   install -m 755 /dev/null %{buildroot}/etc/init.d/$i
 done
-#
-install -d -m 755 %buildroot%{_libexecdir}/initscripts/legacy-actions
 # keep as ghost for migration
 touch %buildroot/etc/inittab
 
@@ -224,8 +222,6 @@ mkdir -p %{buildroot}%{_fillupdir}
 /usr/share/man/man8/service.8*
 /usr/lib/sysctl.d/50-default.conf
 /usr/lib/sysctl.d/51-network.conf
-%dir %{_libexecdir}/initscripts
-%dir %{_libexecdir}/initscripts/legacy-actions
 %{_fillupdir}/sysconfig.language
 %{_fillupdir}/sysconfig.proxy
 %{_fillupdir}/sysconfig.windowmanager

--- a/files/usr/sbin/service
+++ b/files/usr/sbin/service
@@ -23,9 +23,6 @@ fi
 #
 RCDIR="/etc/init.d"
 
-# legacy actions
-actiondir="/usr/libexec/initscripts/legacy-actions"
-
 #
 # Clean environment
 #
@@ -105,9 +102,6 @@ exec_rc ()
 		fi
 		echo "$1 is neither service nor target!?" >&2
 		return "1"
-	elif [ -n "$2" -a -x "$actiondir/$1/$2" ]; then
-		rc="$actiondir/$1/$2"
-		shift 2
 	elif [ ${0##*/} = service ] ; then
 		echo "Usage: $0 "$1" {start|stop|reload|restart|try-restart|force-reload|status}"
 		return 1

--- a/files/usr/share/man/man8/service.8
+++ b/files/usr/share/man/man8/service.8
@@ -14,15 +14,8 @@ The \fBSERVICE\fR parameter specifies a systemd service name to operate on.
 The supported values of \fBACTION\fR depend  on  the specified  service.
 The actions start, stop, reload, restart, try-restart, force-reload, and status
 are forwarded to systemctl, \fBOPTIONS\fR are ignored in that case.
-Other actions may be defined in /usr/lib/initscripts/legacy-actions. Legacy
-actions are called directly and \fBOPTIONS\fR are passed on the command line.
 
 The \-\-status-all option displays the status of all loaded service units.
-
-.SH FILES
-/usr/lib/initscripts/legacy-actions
-              Directory containing System V legacy actions
-.BR 
 
 .SH HISTORY
 service used to run System V init scripts in a predictable environment.


### PR DESCRIPTION
There is nothing left using the legacy-actions directory. Remove it so that nobody will introduce new scripts here.
This is part of the SysV init support removal from PED-264 and PED-266.