### PR TITLE
Don't fail when kernel.pid_max fails to be set (bsc#1227117)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ all: $(bin_PROGRAMS)
 install: all
 	cp -a files/* $(DESTDIR)/
 	install -m755 get_kernel_version $(DESTDIR)/usr/bin
+ifneq ($(filter i%86 armv%,$(RPM_ARCH)),)
+	rm -vf $(DESTDIR)/usr/lib/sysctl.d/50-pid-max.conf
+endif
 
 clean:
 	rm -f $(bin_PROGRAMS)

--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -221,6 +221,9 @@ mkdir -p %{buildroot}%{_fillupdir}
 /usr/share/man/man5/defaultdomain.5*
 /usr/share/man/man8/service.8*
 /usr/lib/sysctl.d/50-default.conf
+%ifnarch %ix86 %arm
+/usr/lib/sysctl.d/50-pid-max.conf
+%endif
 /usr/lib/sysctl.d/51-network.conf
 %{_fillupdir}/sysconfig.language
 %{_fillupdir}/sysconfig.proxy

--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -56,10 +56,6 @@ fs.inotify.max_user_instances = 8192
 # default 184 = 128+32+16+8
 kernel.sysrq = 184
 
-# Remove pid_max limit by setting maximum possible value
-# (bsc#1219038,  https://www.suse.com/support/kb/doc/?id=000020429)
-kernel.pid_max = 4194304
-
 # enable hard- and symlink protection (bnc#821585)
 fs.protected_hardlinks = 1
 fs.protected_symlinks = 1

--- a/files/usr/lib/sysctl.d/50-pid-max.conf
+++ b/files/usr/lib/sysctl.d/50-pid-max.conf
@@ -1,0 +1,3 @@
+# Remove pid_max limit by setting maximum possible value on 64b kernels
+# (bsc#1219038,  https://www.suse.com/support/kb/doc/?id=000020429)
+kernel.pid_max = 4194304


### PR DESCRIPTION
32b kernels only allow 2^15 of pid_max at most. sysctl write fails with EINVAL on such archs. Adjust the sysctl entry so that the write is not considered a fatal error for whole systemd-sysctl.service.