### PR TITLE
Add helper service for soft-reboot

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -154,6 +154,12 @@ mkdir -p %{buildroot}%{_fillupdir}
   rm -vrf %{buildroot}/usr/share/fillup-templates
 %endif
 
+%pre
+%service_add_pre soft-reboot-cleanup.service
+
+%preun
+%service_del_preun soft-reboot-cleanup.service
+
 %post
 export LC_ALL=C
 
@@ -169,6 +175,10 @@ fi
 
 %{fillup_only -n language}
 %{fillup_only -n proxy}
+%service_add_post soft-reboot-cleanup.service
+
+%postun
+%service_del_postun_without_restart soft-reboot-cleanup.service
 
 %pre extras
 %service_add_pre backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer
@@ -217,6 +227,8 @@ fi
 /usr/etc/profile.d/terminal.csh
 %dir /usr/lib/environment.d
 /usr/lib/environment.d/50-xdg.conf
+/usr/lib/systemd/system/soft-reboot-cleanup.service
+/usr/libexec/soft-reboot-cleanup
 %{_tmpfilesdir}/soft-reboot-cleanup.conf
 %config /etc/shells
 %ghost %dir /etc/init.d
@@ -247,7 +259,7 @@ fi
 /usr/lib/base-scripts/backup-rpmdb
 /usr/lib/base-scripts/backup-sysconfig
 /usr/lib/base-scripts/check-battery
-/usr/lib/systemd/system/*
+/usr/lib/systemd/system/[bc]*
 /var/adm/backup/rpmdb
 /var/adm/backup/sysconfig
 %{_fillupdir}/sysconfig.backup

--- a/files/usr/lib/systemd/system/soft-reboot-cleanup.service
+++ b/files/usr/lib/systemd/system/soft-reboot-cleanup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Cleanup system data after soft-reboot
+Before=network-pre.target
+Wants=network-pre.target
+Before=iptables.service ip6tables.service ebtables.service ipset.service nftables.service
+Before=firewalld.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/soft-reboot-cleanup
+RemainAfterExit=true
+
+[Install]
+WantedBy=default.target

--- a/files/usr/libexec/soft-reboot-cleanup
+++ b/files/usr/libexec/soft-reboot-cleanup
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# A normal reboot clears the kernel tables, a soft-reboot does
+# not. Do this manually to avoid problems with old, outdated rules.
+if [ -x /usr/sbin/iptables ]; then
+	iptables -F
+fi
+if [ -x /usr/sbin/nft ]; then
+	nft flush ruleset
+fi


### PR DESCRIPTION
If you do a soft-reboot, the kernel will not rebooted and thus the iptables/nft rulesets will stay and can make trouble.
Clear them at boot time.