### PR TITLE
sysctl: Fixup of not setting kernel.pid_max on 32b archs (bsc#1227117)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: $(bin_PROGRAMS)
 install: all
 	cp -a files/* $(DESTDIR)/
 	install -m755 get_kernel_version $(DESTDIR)/usr/bin
-ifneq ($(filter i%86 armv%,$(RPM_ARCH)),)
+ifneq ($(filter i%86 arm%,$(RPM_ARCH)),)
 	rm -vf $(DESTDIR)/usr/lib/sysctl.d/50-pid-max.conf
 endif
 


### PR DESCRIPTION
The fix in commit c0879589bc2f94c3b4be6d41c34465855f3b3163 got the RPM_ARCH filter wrong, so packaging failed. The values to match against are:
  - 'arm' for 32b and
  - 'aarch64' for 64b (they are different values than what RPM macros contain).

Cc: @ggardet