### PR TITLE
yama-enable-ptrace: enforce changed behavior upon installation (bsc#1221763)

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -169,6 +169,22 @@ mkdir -p %{buildroot}%{_fillupdir}
 %postun extras
 %service_del_postun backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer
 
+%post yama-enable-ptrace
+# check if yama is active
+if [ -f /proc/sys/kernel/yama/ptrace_scope ]; then
+  # automatically disable ptrace protection upon install if systemd is not
+  # available. Usually system will automatically apply the setting
+  if ! type -p systemd-notify > /dev/null || ! systemd-notify --booted; then
+    # don't do it on transactional systems to avoid altering the state of the
+    # system before reboot
+    if [ -z "${TRANSACTIONAL_UPDATE}" ]; then
+      # can't use sysctl since that would cause us to require procps, which is
+      # bad for container size
+      echo 0 > /proc/sys/kernel/yama/ptrace_scope || :
+    fi
+  fi
+fi
+
 %files
 %license COPYING
 %ghost %config(noreplace) /etc/sysctl.conf


### PR DESCRIPTION
not just install the file to permanetely change the system setting, but also change the setting right away. On most systems this is not necessary, as systemd will handle it. But on our build machines this mechanism doens't work and causes issues