### PR TITLE
profile.{sh,csh}: Drop useless proxy variables cleanup

### DIFF
--- a/files/usr/etc/profile.d/profile.csh
+++ b/files/usr/etc/profile.d/profile.csh
@@ -98,7 +98,7 @@ foreach line ( "`/usr/bin/grep -vh '^#' $sysconf`" )
 	breaksw
     endsw
 end
-unset sysconf line
+unset sysconf line proxy_enabled
 
 if ( -d /usr/lib/dvgt_help ) then
     setenv DV_IMMED_HELP /usr/lib/dvgt_help
@@ -106,13 +106,6 @@ endif
 
 if ( -d /usr/lib/rasmol ) then
     setenv RASMOLPATH /usr/lib/rasmol
-endif
-
-if ( ${?proxy_enabled} ) then
-    if ( "$proxy_enabled" != "yes" ) then
-	unsetenv http_proxy https_proxy ftp_proxy gopher_proxy no_proxy socks_proxy SOCKS_PROXY SOCKS5_SERVER
-    endif
-    unset proxy_enabled
 endif
 
 #

--- a/files/usr/etc/profile.d/profile.sh
+++ b/files/usr/etc/profile.d/profile.sh
@@ -95,7 +95,7 @@ do
 	esac
     done < $_sys
 done
-unset -v _sys _line _val
+unset -v _sys _line _val PROXY_ENABLED
 
 if test -d /usr/lib/dvgt_help ; then
     DV_IMMED_HELP=/usr/lib/dvgt_help
@@ -106,11 +106,6 @@ if test -d /usr/lib/rasmol ; then
     RASMOLPATH=/usr/lib/rasmol
     export RASMOLPATH
 fi
-
-if test "$PROXY_ENABLED" != "yes" ; then
-    unset -v http_proxy https_proxy ftp_proxy gopher_proxy no_proxy NO_PROXY socks_proxy SOCKS_PROXY SOCKS5_SERVER
-fi
-unset -v PROXY_ENABLED
 
 if test -z "$WINDOWMANAGER" ; then
     _SAVEPATH=$PATH


### PR DESCRIPTION
Since commit 92f627f5f8cf ("set unused proxy variables to empty values"), proxy variables are only set (possibly empty) if PROXY_ENABLED="yes". Therefore, the cleanup code is no longer doing anything and can be removed.