### PR TITLE
Add setup-systemd-proxy-env

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -181,17 +181,17 @@ fi
 %service_del_postun_without_restart soft-reboot-cleanup.service
 
 %pre extras
-%service_add_pre backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer
+%service_add_pre backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer setup-systemd-proxy-env.path setup-systemd-proxy-env.service
 
 %post extras
 %fillup_only -n backup
-%service_add_post backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer
+%service_add_post backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer setup-systemd-proxy-env.path setup-systemd-proxy-env.service
 
 %preun extras
-%service_del_preun backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer
+%service_del_preun backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer setup-systemd-proxy-env.path setup-systemd-proxy-env.service
 
 %postun extras
-%service_del_postun backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer
+%service_del_postun backup-rpmdb.service backup-rpmdb.timer backup-sysconfig.service backup-sysconfig.timer check-battery.service check-battery.timer setup-systemd-proxy-env.path setup-systemd-proxy-env.service
 
 %post yama-enable-ptrace
 # check if yama is active
@@ -269,6 +269,7 @@ fi
 %{_fillupdir}/sysconfig.proxy
 
 %files extras
+/usr/bin/setup-systemd-proxy-env
 /usr/etc/skel/.emacs
 /usr/etc/skel/.inputrc
 %dir /usr/lib/base-scripts
@@ -276,6 +277,7 @@ fi
 /usr/lib/base-scripts/backup-sysconfig
 /usr/lib/base-scripts/check-battery
 /usr/lib/systemd/system/[bc]*
+/usr/lib/systemd/system/setup-systemd-proxy-env.*
 /var/adm/backup/rpmdb
 /var/adm/backup/sysconfig
 %{_fillupdir}/sysconfig.backup

--- a/files/usr/bin/setup-systemd-proxy-env
+++ b/files/usr/bin/setup-systemd-proxy-env
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Look at /etc/sysconfig/proxy and make the proxy configuration
+# available as environment variable in systemd services
+
+CFG=/etc/sysconfig/proxy
+SYSTEMD_CFG=/etc/systemd/system.conf.d/proxy.conf
+
+test -f ${CFG} || exit 0
+
+DefaultEnvironment=""
+
+while read line ; do
+    case "$line" in
+        \#*|"") continue ;;
+    esac
+    eval val=${line#*=}
+    test -z "$val" && continue
+    case "$line" in
+        PROXY_ENABLED=*)
+	    test "$val" = "yes" && continue
+	    if [ -f $SYSTEMD_CFG ]; then
+		rm $SYSTEMD_CFG
+		systemctl daemon-reload
+	    fi
+	    exit 0
+	    ;;
+        HTTP_PROXY=*)
+            DefaultEnvironment="$DefaultEnvironment \"HTTP_PROXY=${val}\" \"http_proxy=${val}\""
+            ;;
+        HTTPS_PROXY=*)
+	    DefaultEnvironment="$DefaultEnvironment \"HTTPS_PROXY=${val}\" \"https_proxy=${val}\""
+            ;;
+        FTP_PROXY=*)
+	    DefaultEnvironment="$DefaultEnvironment \"FTP_PROXY=${val}\" \"ftp_proxy=${val}\""
+            ;;
+        GOPHER_PROXY=*)
+	    DefaultEnvironment="$DefaultEnvironment \"GOPHER_PROXY=${val}\" \"gopher_proxy=${val}\""
+            ;;
+        SOCKS_PROXY=*)
+	    DefaultEnvironment="$DefaultEnvironment \"SOCKS_PROXY=${val}\" \"socks_proxy=${val}\""
+            ;;
+        SOCKS5_SERVER=*)
+	    DefaultEnvironment="$DefaultEnvironment \"SOCKS5_SERVER=${val}\" \"socks5_server=${val}\""
+            ;;
+        NO_PROXY=*)
+	    DefaultEnvironment="$DefaultEnvironment \"NO_PROXY=${val}\" \"no_proxy=${val}\""
+            ;;
+    esac
+done < $CFG
+
+test -z "$DefaultEnvironment" && exit 0
+
+if [ ! -d /etc/systemd/system.conf.d ]; then
+    mkdir -p /etc/systemd/system.conf.d || exit 1
+fi
+
+TMPCFGFILE=`mktemp ${SYSTEMD_CFG}.XXXXXXXXXX` || exit 1
+echo -e "[Manager]\nDefaultEnvironment=${DefaultEnvironment}" > ${TMPCFGFILE}
+cmp -s ${TMPCFGFILE} ${SYSTEMD_CFG}
+if [ $? -ne 0 ]; then
+    chmod 0644 ${TMPCFGFILE}
+    mv ${TMPCFGFILE} ${SYSTEMD_CFG}
+    systemctl daemon-reload
+else
+    rm -f $TMPCFGFILE
+fi
+
+exit 0

--- a/files/usr/lib/systemd/system/setup-systemd-proxy-env.path
+++ b/files/usr/lib/systemd/system/setup-systemd-proxy-env.path
@@ -1,0 +1,11 @@
+[Unit]
+Description=Watch for changes in proxy configuration
+After=local-fs.target
+
+[Path]
+Unit=setup-systemd-proxy-env.service
+PathChanged=/etc/sysconfig/proxy
+
+[Install]
+WantedBy=default.target
+

--- a/files/usr/lib/systemd/system/setup-systemd-proxy-env.service
+++ b/files/usr/lib/systemd/system/setup-systemd-proxy-env.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Update system wide proxy setup for systemd services
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/setup-systemd-proxy-env
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
setup-systemd-proxy-env is a script and systemd services to generate a systemd wide proxy setup for systemd services based on /etc/sysconfig/proxy.

The script and service files where part of microos-tools until now, but due to the interest of having the same functionality for SLES16 moved to here.