### PR TITLE
Use explicit defaults for XDG environment variables

### DIFF
--- a/files/usr/etc/profile.d/xdg-environment.csh
+++ b/files/usr/etc/profile.d/xdg-environment.csh
@@ -1,2 +1,30 @@
 # keep in sync with /usr/lib/environment.d/50-xdg.conf
-setenv XDG_CONFIG_DIRS "/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg"
+# System XDG - SUSE configured
+if ( ! ${?XDG_CONFIG_DIRS} ) then
+  setenv XDG_CONFIG_DIRS /etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg
+endif
+
+# System XDG - explicit defaults
+if ( ! ${?XDG_DATA_DIRS} ) then
+  setenv XDG_DATA_DIRS /usr/local/share/:/usr/share/
+endif
+
+# User XDG - explicit defaults
+if (! ${?XDG_DATA_HOME} && ${?HOME} ) then
+  setenv XDG_DATA_HOME $HOME/.local/share
+endif
+if (! ${?XDG_CONFIG_HOME} && ${?HOME} ) then
+  setenv XDG_CONFIG_HOME $HOME/.config
+endif
+if (! ${?XDG_STATE_HOME} && ${?HOME} ) then
+  setenv XDG_STATE_HOME $HOME/.local/state
+endif
+if (! ${?XDG_CACHE_HOME} && ${?HOME} ) then
+  setenv XDG_CACHE_HOME $HOME/.cache
+endif
+
+# XDG_RUNTIME_DIR is set by pam_systemd
+
+
+
+ 

--- a/files/usr/etc/profile.d/xdg-environment.sh
+++ b/files/usr/etc/profile.d/xdg-environment.sh
@@ -1,3 +1,22 @@
 # keep in sync with /usr/lib/environment.d/50-xdg.conf
-XDG_CONFIG_DIRS='/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg'
+# System XDG - SUSE configured
+XDG_CONFIG_DIRS=${XDG_CONFIG_DIRS:-/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg}
 export XDG_CONFIG_DIRS
+
+# System XDG - explicit defaults
+XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}
+export XDG_DATA_DIRS
+
+# User XDG - explicit defaults
+XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME:+$HOME/.local/share}}
+export XDG_DATA_HOME
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME:+$HOME/.config}}
+export XDG_CONFIG_HOME
+XDG_STATE_HOME=${XDG_STATE_HOME:-${HOME:+$HOME/.local/state}}
+export XDG_STATE_HOME
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-${HOME:+$HOME/.cache}}
+export XDG_CACHE_HOME
+
+# XDG_RUNTIME_DIR is set by pam_systemd
+
+

--- a/files/usr/lib/environment.d/50-xdg.conf
+++ b/files/usr/lib/environment.d/50-xdg.conf
@@ -1,8 +1,15 @@
 # XDG directories, see
 # https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
 #
+# System XDG - SUSE configured
 # According to spec this would only read /etc when unset
-XDG_CONFIG_DIRS=/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg
+XDG_CONFIG_DIRS=${XDG_CONFIG_DIRS:-/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg}
 #
-# This is actually the implicit default, no need to set
-# XDG_DATA_DIRS=/usr/local/share/:/usr/share/
+# System XDG - explicit default
+XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}
+
+# User XDG - explicit default
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME:+$HOME/.config}}
+XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME:+$HOME/.local/share}}
+XDG_STATE_HOME=${XDG_STATE_HOME:-${HOME:+$HOME/.local/state}}
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-${HOME:+$HOME/.cache}}


### PR DESCRIPTION
Some applications fail to follow spec and use a random directory under $HOME if we don't explicitly support XDG