### PR TITLE
Modern s390x uses TERM=linux for ttysclp<X>

### DIFF
--- a/files/etc/csh.login
+++ b/files/etc/csh.login
@@ -27,9 +27,16 @@ if ( -o /dev/$tty && -c /dev/$tty && ${?prompt} ) then
     if ( "$TERM" == "unknown" ) setenv TERM linux
     if ( "$TERM" == "ibm327x" ) setenv TERM dumb
     if ( `uname -m` == "s390x" ) then
-	if ( "$tty" == "/dev/sclp_line0" || "$tty" == "/dev/ttyS0" ) then
-	    if ( "$TERM" == "vt220" ) setenv TERM dumb
-	endif
+	switch ("${tty:t}")
+	case ttysclp0
+	case ttysclp1
+	case ttyS0
+	case ttyS1
+	    if ( "$TERM" == "vt220" ) setenv TERM linux
+	    breaksw
+	default
+	    breaksw
+	endsw
     endif
     if ( $TERM =~ screen.* && ! -e /usr/share/terminfo/s/$TERM) setenv TERM screen
     if ( ! ${?SSH_TTY} && "$TERM" != "dumb" ) then

--- a/files/etc/profile
+++ b/files/etc/profile
@@ -80,8 +80,8 @@ if test -O "$tty" -a -n "$PS1"; then
     test "${TERM}" = "unknown"	&& { TERM=linux; export TERM; }
     test "${TERM}" = "ibm327x"	&& { TERM=dumb;  export TERM; }
     if test "$(uname -m)" = "s390x" ; then
-	if test "$tty" = "/dev/sclp_line0" -o "$tty" = "/dev/ttyS0" ; then
-	    test "${TERM}" = "vt220" && { TERM=dumb;  export TERM; }
+	if test "${tty%[0-9]}" = "/dev/ttysclp" -o "${tty%[0-9]}" = "/dev/ttyS" ; then
+	    test "${TERM}" = "vt220" && { TERM=linux;  export TERM; }
 	fi
     fi
     case "$TERM" in


### PR DESCRIPTION
with TERM=vt220 the alternated screen does not work.