### PR TITLE
Modern s390x uses TERM=linux for ttysclp<X>

### DIFF
--- a/files/etc/csh.login
+++ b/files/etc/csh.login
@@ -27,9 +27,23 @@ if ( -o /dev/$tty && -c /dev/$tty && ${?prompt} ) then
     if ( "$TERM" == "unknown" ) setenv TERM linux
     if ( "$TERM" == "ibm327x" ) setenv TERM dumb
     if ( `uname -m` == "s390x" ) then
-	if ( "$tty" == "/dev/sclp_line0" || "$tty" == "/dev/ttyS0" ) then
+	switch ("${tty:t}")
+	case ttysclp0
+	case ttysclp1
+	    if ( -s /usr/share/terminfo/s/sclp ) then
+		setenv TERM sclp
+	    else if ( -s /usr/share/terminfo/x/xterm-vt220 ) then
+		setenv TERM xterm-vt220
+	    else
+		setenv TERM vt220
+	    breaksw
+	case sclp_line0
+	case ttyS0
 	    if ( "$TERM" == "vt220" ) setenv TERM dumb
-	endif
+	    breaksw
+	default
+	    breaksw
+	endsw
     endif
     if ( $TERM =~ screen.* && ! -e /usr/share/terminfo/s/$TERM) setenv TERM screen
     if ( ! ${?SSH_TTY} && "$TERM" != "dumb" ) then

--- a/files/etc/profile
+++ b/files/etc/profile
@@ -80,13 +80,23 @@ if test -O "$tty" -a -n "$PS1"; then
     test "${TERM}" = "unknown"	&& { TERM=linux; export TERM; }
     test "${TERM}" = "ibm327x"	&& { TERM=dumb;  export TERM; }
     if test "$(uname -m)" = "s390x" ; then
+	if test "${tty%[0-9]}" = "/dev/ttysclp" ; then
+	    if test -s /usr/share/terminfo/s/sclp; then
+		TERM=sclp
+	    elif test -s /usr/share/terminfo/x/xterm-vt220; then
+		TERM=xterm-vt220
+	    else
+		TERM=vt220
+	    fi
+	    export TERM
+	fi
 	if test "$tty" = "/dev/sclp_line0" -o "$tty" = "/dev/ttyS0" ; then
-	    test "${TERM}" = "vt220" && { TERM=dumb;  export TERM; }
+	    test "${TERM}" = "vt220" && { TERM=dumb; export TERM; }
 	fi
     fi
     case "$TERM" in
     screen.*)
-	test -e /usr/share/terminfo/s/${TERM} || { TERM=screen;  export TERM; } ;;
+	test -e /usr/share/terminfo/s/${TERM} || { TERM=screen; export TERM; } ;;
     esac
     # Do not change settings on local line if connected to remote
     if test -z "$SSH_TTY" -a "${TERM}" != "dumb" ; then

--- a/files/usr/etc/DIR_COLORS
+++ b/files/usr/etc/DIR_COLORS
@@ -60,6 +60,7 @@ TERM screen.rxvt
 TERM screen-w
 TERM screen.xterm
 TERM screen.xterm-256color
+TERM sclp*
 TERM st
 TERM terminator
 TERM tmux


### PR DESCRIPTION
with TERM=vt220 the alternated screen does not work. Support coloring with latest terminfo sclp for ttcsclp0