### PR TITLE
alias.bash: future-proof egrep/fgrep color aliases

### DIFF
--- a/files/usr/etc/profile.d/alias.bash
+++ b/files/usr/etc/profile.d/alias.bash
@@ -24,8 +24,8 @@ if test "$is" != "ksh" ; then
     alias -- -='popd'
 fi
 alias rd=rmdir
-alias egrep='egrep --color=auto'
-alias fgrep='fgrep --color=auto'
+alias egrep='grep -E --color=auto'
+alias fgrep='grep -F --color=auto'
 alias grep='grep --color=auto'
 if ip --color=auto -V > /dev/null 2>/dev/null ; then
     alias ip='ip --color=auto'


### PR DESCRIPTION
future-proof `egrep`/`fgrep` color aliases in `alias.bash`. Point to `grep -E` and `[...] -F`, respectively, so they won't fail even if removed eventually.

See [SR#1268489](https://build.opensuse.org/request/show/1268489), [deprecation notice](https://git.savannah.gnu.org/cgit/grep.git/tree/NEWS?h=v3.8#n10), [compatibility notice](https://git.savannah.gnu.org/cgit/grep.git/tree/NEWS?h=v3.8#n1177).
