### PR TITLE
Allow /etc/locale.conf to have no newline

### DIFF
--- a/files/usr/etc/profile.d/lang.sh
+++ b/files/usr/etc/profile.d/lang.sh
@@ -51,7 +51,7 @@ fi
 #
 ROOT_USES_LANG=yes
 if test -s /etc/locale.conf ; then
-    while read line ; do
+    while read line || test -n "$line" ; do
 	case "$line" in
 	\#*|"")
 		continue


### PR DESCRIPTION
for the first and only line.  As the 'read' builtin of the bash returns false, test if we have a '$line' set and go further.