### PR TITLE
prevent normal users from accessing dmesg (bsc#1249686)

### DIFF
--- a/files/usr/lib/sysctl.d/50-default.conf
+++ b/files/usr/lib/sysctl.d/50-default.conf
@@ -65,3 +65,6 @@ fs.protected_fifos = 2
 
 # restrict printed kernel ptrs (bnc#833774)
 kernel.kptr_restrict = 1
+
+# prevent normal users from seeing dmesg (bsc#1249686) 
+kernel.dmesg_restrict = 1


### PR DESCRIPTION
If users don't like it they can override this. Discussion either here or in the bug