### PR TITLE
Revert ec7f00fa60f11d28b427f2e224822a7b81825806

### DIFF
--- a/files/usr/etc/profile.d/xdg-environment.csh
+++ b/files/usr/etc/profile.d/xdg-environment.csh
@@ -5,26 +5,6 @@ if ( ! ${?XDG_CONFIG_DIRS} ) then
 endif
 
 # System XDG - explicit defaults
-if ( ! ${?XDG_DATA_DIRS} ) then
-  setenv XDG_DATA_DIRS /usr/local/share:/usr/share
-endif
-
-# User XDG - explicit defaults
-if (! ${?XDG_DATA_HOME} && ${?HOME} ) then
-  setenv XDG_DATA_HOME $HOME/.local/share
-endif
-if (! ${?XDG_CONFIG_HOME} && ${?HOME} ) then
-  setenv XDG_CONFIG_HOME $HOME/.config
-endif
-if (! ${?XDG_STATE_HOME} && ${?HOME} ) then
-  setenv XDG_STATE_HOME $HOME/.local/state
-endif
-if (! ${?XDG_CACHE_HOME} && ${?HOME} ) then
-  setenv XDG_CACHE_HOME $HOME/.cache
-endif
+if ( ! ${?XDG_DATA_DIRS} ) setenv XDG_DATA_DIRS /usr/local/share:/usr/share
 
 # XDG_RUNTIME_DIR is set by pam_systemd
-
-
-
- 

--- a/files/usr/etc/profile.d/xdg-environment.sh
+++ b/files/usr/etc/profile.d/xdg-environment.sh
@@ -7,16 +7,4 @@ export XDG_CONFIG_DIRS
 XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
 export XDG_DATA_DIRS
 
-# User XDG - explicit defaults
-XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME:+$HOME/.local/share}}
-export XDG_DATA_HOME
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME:+$HOME/.config}}
-export XDG_CONFIG_HOME
-XDG_STATE_HOME=${XDG_STATE_HOME:-${HOME:+$HOME/.local/state}}
-export XDG_STATE_HOME
-XDG_CACHE_HOME=${XDG_CACHE_HOME:-${HOME:+$HOME/.cache}}
-export XDG_CACHE_HOME
-
 # XDG_RUNTIME_DIR is set by pam_systemd
-
-

--- a/files/usr/lib/environment.d/50-xdg.conf
+++ b/files/usr/lib/environment.d/50-xdg.conf
@@ -1,15 +1,11 @@
 # XDG directories, see
-# https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
+# https://specifications.freedesktop.org/basedir/latest/
 #
 # System XDG - SUSE configured
 # According to spec this would only read /etc when unset
 XDG_CONFIG_DIRS=${XDG_CONFIG_DIRS:-/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg}
+
 #
 # System XDG - explicit default
 XDG_DATA_DIRS=${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
 
-# User XDG - explicit default
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME:+$HOME/.config}}
-XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME:+$HOME/.local/share}}
-XDG_STATE_HOME=${XDG_STATE_HOME:-${HOME:+$HOME/.local/state}}
-XDG_CACHE_HOME=${XDG_CACHE_HOME:-${HOME:+$HOME/.cache}}


### PR DESCRIPTION
This commit interferes with XDG environment setting used by su, su -, kdesu, and gnomesu.  Better use the pam_env.conf of the pam_env.so module to set this explicit for the *current* user including root.