### PR TITLE
alias.bash: restore `|| echo 0` sequence after `tput colors`

### DIFF
--- a/files/usr/etc/profile.d/alias.bash
+++ b/files/usr/etc/profile.d/alias.bash
@@ -24,7 +24,7 @@ if test "$is" != "ksh" ; then
     alias -- -='popd'
 fi
 alias rd=rmdir
-if type -p tput >/dev/null 2>&1 && test -n "$TERM" -a -t 1 && test "$(tput colors)" -ge 8 ; then
+if type -p tput >/dev/null 2>&1 && test -n "$TERM" -a -t 1 && test "$(tput colors || echo 0)" -ge 8 ; then
     alias egrep='grep -E --color=auto'
     alias fgrep='grep -F --color=auto'
     alias grep='grep --color=auto'


### PR DESCRIPTION
It is possible for `test "$(tput colors)" -ge 8` to throw a `-bash: test: : integer expected` exception.

In commit 983fd43c3d4cd687bca1802577a98930e1b23d88, `tput colors` was always followed by `|| echo 0`, because tput does not output anything if there are no definitions for the current $TERM value. This got lost in commit 5486aadee23a19422cc54064dc6c95ee47f87cf8.
