### PR TITLE
DIR_COLORS: add vt220 and .jxl

### DIFF
--- a/files/usr/etc/DIR_COLORS
+++ b/files/usr/etc/DIR_COLORS
@@ -67,6 +67,7 @@ TERM tmux
 TERM tmux-256color
 TERM vt100
 TERM vt102
+TERM vt220
 TERM xterm
 TERM xterm-16color
 TERM xterm-256color
@@ -189,6 +190,7 @@ EXEC 01;32
 .gl 01;35
 .jpeg 01;35
 .jpg 01;35
+.jxl 01;35
 .m2v 01;35
 .m4v 01;35
 .mjpeg 01;35


### PR DESCRIPTION
Upstream added these two ([1](https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=f2e323430193956709aacca33f6b4fcab4fb9d8b), [2](https://cgit.git.savannah.gnu.org/cgit/coreutils.git/commit/?id=76b8121d62c709e3066011b094afecd3dbbb9dc4)) last year, include them in our version.