### PR TITLE
drop dirs from the specfile, they live in the filesystem package (boo#1253493)

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -254,10 +254,7 @@ fi
 /usr/etc/profile.d/ls.zsh
 /usr/etc/profile.d/terminal.sh
 /usr/etc/profile.d/terminal.csh
-%dir /usr/etc/security/
-%dir /usr/etc/security/pam_env.conf.d/
 /usr/etc/security/pam_env.conf.d/xdg.conf
-%dir /usr/lib/environment.d
 /usr/lib/environment.d/50-xdg.conf
 /usr/lib/systemd/system/soft-reboot-cleanup.service
 /usr/libexec/soft-reboot-cleanup


### PR DESCRIPTION
-%dir /usr/etc/security/
-%dir /usr/etc/security/pam_env.conf.d/
-%dir /usr/lib/environment.d