### PR TITLE
Fix a typo + follow symlinks

### DIFF
--- a/files/usr/etc/profile.d/alljava.csh
+++ b/files/usr/etc/profile.d/alljava.csh
@@ -14,11 +14,13 @@ if ( $? == 0 ) then
     alts -t java >& /dev/null
     if ( $? == 0 ) then
         set JAVA_TARGET `alts -t java`
+        set JAVA_TARGET `realpath $JAVA_TARGET`
     endif
 
     alts -t javac >& /dev/null
     if ( $? == 0 ) then
         set JAVAC_TARGET `alts -t javac`
+        set JAVAC_TARGET `realpath $JAVAC_TARGET`
     endif
 endif
 

--- a/files/usr/etc/profile.d/alljava.sh
+++ b/files/usr/etc/profile.d/alljava.sh
@@ -11,11 +11,11 @@
 
 if command -v alts >/dev/null 2>&1; then
     if alts -t java >/dev/null 2>&1; then
-        JAVA_TARGET=$(alts -t java)
+        JAVA_TARGET=$(realpath $(alts -t java))
     fi
 
     if alts -t javac >/dev/null 2>&1; then
-        JAVAC_TARGET=$(alts -t javac)
+        JAVAC_TARGET=$(realpath $(alts -t javac))
     fi
 fi
 
@@ -32,7 +32,7 @@ if [ -z "$JAVAC_TARGET" ]; then
 fi
 
 if [ ! -z "$JAVA_TARGET" ]; then
-    export JRE_HOME="${JRE_HOME%/bin/java}"
+    export JRE_HOME="${JAVA_TARGET%/bin/java}"
     unset JAVA_TARGET
 fi
 


### PR DESCRIPTION
In the haste of Friday, we introduced this typo and the JRE_HOME was not set correctly. Not many things use it, so it was not seen in Factory integration. Nevertheless, it is good to have it correctly fixed.

In the same token, I added a realpath call on the output of alts -t call. Since we use still levels of symlinks in java-X-openjdk and java-X-openj9, it is better to have them all properly resolved for the environmental variables.