### PR TITLE
fix(ls): avoid breaking sudo alias expansion

### DIFF
--- a/aaa_base.spec
+++ b/aaa_base.spec
@@ -251,7 +251,6 @@ fi
 /usr/etc/profile.d/alias.tcsh
 /usr/etc/profile.d/ls.tcsh
 /usr/etc/profile.d/ls.bash
-/usr/etc/profile.d/ls.zsh
 /usr/etc/profile.d/terminal.sh
 /usr/etc/profile.d/terminal.csh
 %dir /usr/etc/security/

--- a/files/usr/etc/profile.d/ls.bash
+++ b/files/usr/etc/profile.d/ls.bash
@@ -47,25 +47,7 @@ case "$-" in
 	unalias ls 2>/dev/null
     fi
     case "$is" in
-	dash|ash)
-	    _ls ()
-	    {
-		local IFS=' '
-		command ls $LS_OPTIONS ${1+"$@"}
-	    }
-	    alias ls=_ls
-	    ;;
 	zsh)
-	    test -s /etc/profile.d/ls.zsh && . /etc/profile.d/ls.zsh
-	    ;;
-	ksh)
-	    function _ls
-	    {
-		typeset IFS=' '
-		command -p ls $LS_OPTIONS ${1+"$@"}
-	    }
-	    alias ls=_ls
-	    ;;
 	*)  alias ls='/usr/bin/ls $LS_OPTIONS' ;;
     esac
     alias dir='ls -l'

--- a/files/usr/etc/profile.d/ls.bash
+++ b/files/usr/etc/profile.d/ls.bash
@@ -47,7 +47,7 @@ case "$-" in
 	unalias ls 2>/dev/null
     fi
     case "$is" in
-	bash|dash|ash)
+	dash|ash)
 	    _ls ()
 	    {
 		local IFS=' '

--- a/files/usr/etc/profile.d/ls.zsh
+++ b/files/usr/etc/profile.d/ls.zsh
@@ -1,6 +1,0 @@
-z_ls ()
-{
-    local IFS=' '
-    command \ls $=LS_OPTIONS ${1+"$@"}
-}
-alias ls=z_ls


### PR DESCRIPTION
Bash and zsh has documented trailing-space alias expansion.

https://www.gnu.org/software/bash/manual/html_node/Aliases.html
```
If the last character of the alias value is a blank, then the shell checks the next command word following the alias for alias expansion.
```

Actually, its part of POSIX definition of `2.3.1 Alias Substitution`:
https://pubs.opengroup.org/onlinepubs/9799919799/
```
Either the TOKEN is being considered for alias substitution because it follows an alias substitution whose replacement value ended with a <blank> (see below) or the TOKEN could be parsed as the command name word of a simple command (see [2.10 Shell Grammar](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_10)), based on this TOKEN and the tokens (if any) that preceded it, but ignoring whether any subsequent characters would allow that.
...
If the value of the alias replacing the TOKEN ends in a <blank> that would be unquoted after substitution, and optionally if it ends in a <blank> that would be quoted after substitution, the shell shall check the next token in the input, if it is a TOKEN, for alias substitution; this process shall continue until a TOKEN is found that is not a valid alias or an alias value does not end in such a <blank>.
```

A very common use for this feature:

```sh
alias sudo='sudo '
```

Which allows user aliases to expand after `sudo`.

Currently with alias above:
```sh
sudo ls
```
Becomes
```
sudo _ls  # '_ls': not found
```

Profile scripts are only read when a shell is interactive. E.g.
```sh
sudo bash -ic '_ls'`  # works
```

`sudo _ls` does not start an interactive shell where `profile.d` functions are; it tries to execute a command named `_ls`.

`_ls` provides controlled `$LS_OPTIONS` word splitting via a local `IFS`, this primarily guards against non-standard shell configurations.

Therefore, I don't think the benefits outweigh breaking this feature as the `profile.d` scripts should have as little side-effects as possible.