### PR TITLE
fix ls bash alias exp

### DIFF
--- a/files/usr/etc/profile.d/ls.bash
+++ b/files/usr/etc/profile.d/ls.bash
@@ -46,10 +46,7 @@ case "$-" in
     if test "$is" != "ash" ; then
 	unalias ls 2>/dev/null
     fi
-    case "$is" in
-	zsh)
-	*)  alias ls='/usr/bin/ls $LS_OPTIONS' ;;
-    esac
+    alias ls='/usr/bin/ls $LS_OPTIONS'
     alias dir='ls -l'
     alias ll='ls -l'
     alias la='ls -la'


### PR DESCRIPTION
- **fix(ls.bash): avoid breaking sudo alias expansion**
- **fix(ls.bash): use alias, func breaks sudo alias**
- **fix(ls): deprecate ls.zsh**

Follows: https://github.com/openSUSE/aaa_base/pull/210